### PR TITLE
Implement lured pokemon notifications

### DIFF
--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -80,11 +80,11 @@ class Alarm_Manager:
                                 }
                         self.lured_seen[pkmn['pokestop_id']] = pkinfo
                         if self.notify_list[name] != "True" :
-                                log.info(name + " notification was not triggered because alarm is disabled.")
+                                log.info("Lured " + name + " notification was not triggered because alarm is disabled.")
                         elif disappear_time < datetime.utcnow() :
-                                log.info(name + " notification was not triggered because time_left had passed.")
+                                log.info("Lured " + name + " notification was not triggered because time_left had passed.")
                         else:
-                                log.info(name + " notication was triggered!")
+                                log.info("Lured " + name + " notication was triggered!")
                                 for alarm in self.alarms:
                                         alarm.pokemon_alert(pkinfo)
                         if len(self.lured_seen) > 10000:

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -21,7 +21,8 @@ class Alarm_Manager:
 			settings = json.load(file)
 			alarm_settings = settings["alarms"]
 			self.notify_list = settings["pokemon"]
-			self.seen = {}
+			self.seen = {}        # key: encounter_id, value: pkinfo
+			self.lured_seen = {}  # key: pokestop_id, value: pkinfo
 			self.alarms = []
 			for alarm in alarm_settings:
 				if alarm['active'] == "True" :
@@ -40,28 +41,13 @@ class Alarm_Manager:
 
 	#Send a notification to alarms about a found pokemon
 	def trigger_pkmn(self, pkmn):
-		if pkmn['encounter_id'] not in self.seen:
-			name = pkmn_name(pkmn['pokemon_id'])
-			dissapear_time = datetime.utcfromtimestamp(pkmn['disappear_time']);
-			pkinfo = {
-				'id': pkmn['pokemon_id'],
-				'name': name,
-				'alert': pkmn_alert_text(name),
-				'gmaps_link': gmaps_link(pkmn['latitude'], pkmn['longitude']),
-				'time_text': pkmn_time_text(dissapear_time),
-				'disappear_time': dissapear_time
-			}
-			self.seen[pkmn['encounter_id']] = pkinfo
-			if self.notify_list[name] != "True" :
-				log.info(name + " notification was not triggered because alarm is disabled.")
-			elif dissapear_time < datetime.utcnow() :
-				log.info(name + " notification was not triggered because time_left had passed.")
-			else:
-				log.info(name + " notication was triggered!")
-				for alarm in self.alarms:
-					alarm.pokemon_alert(pkinfo)
-		if len(self.seen) > 10000 :
-			self.clear_stale();
+		if 'encounter_id' in pkmn:
+			trigger_normal_pkmn(self, pkmn)
+		elif 'pokestop_id' in pkmn:
+			trigger_lured_pkmn(self, pkmn)
+		else:
+			raise ValueError("Pokemon is not normal nor lured.")
+
 
 	#Send a notication about pokemon lure found
 	def notify_lures(self, lures):
@@ -72,10 +58,69 @@ class Alarm_Manager:
 		raise NotImplementedError("This method is not yet implimented.")
 
 	#clear expired pokemon so that the seen set is not too large
-	def clear_stale(self):
-		old = []
-		for id in self.seen:
-			if self.seen[id]['disappear_time'] < datetime.utcnow() :
-				old.append(id)
-		for id in old:
-			del self.seen[id]
+	def clear_stale(self, normal=False, lured=False):
+		if normal:
+			old = []
+			for id in self.seen:
+				if self.seen[id]['disappear_time'] < datetime.utcnow():
+					old.append(id)
+			for id in old:
+				del self.seen[id]
+		elif lured:
+			old = []
+			for id in self.lured_seen:
+				if self.lured_seen[id]['disappear_time'] < datetime.utcnow():
+					old.append(id)
+			for id in old:
+				del self.lured_seen[id]
+
+def trigger_normal_pkmn(self, pkmn):
+	if pkmn['encounter_id'] not in self.seen:
+		name = pkmn_name(pkmn['pokemon_id'])
+		disappear_time = datetime.utcfromtimestamp(pkmn['disappear_time']);
+		pkinfo = {
+			'id': pkmn['pokemon_id'],
+			'name': name,
+			'alert': pkmn_alert_text(name),
+			'gmaps_link': gmaps_link(pkmn['latitude'], pkmn['longitude']),
+			'time_text': pkmn_time_text(disappear_time),
+			'disappear_time': disappear_time
+			}
+		self.seen[pkmn['encounter_id']] = pkinfo
+		if self.notify_list[name] != "True" :
+			log.info(name + " notification was not triggered because alarm is disabled.")
+		elif disappear_time < datetime.utcnow() :
+			log.info(name + " notification was not triggered because time_left had passed.")
+		else:
+			log.info(name + " notication was triggered!")
+			for alarm in self.alarms:
+				alarm.pokemon_alert(pkinfo)
+		if len(self.seen) > 10000 :
+			self.clear_stale(normal=True);
+
+def trigger_lured_pkmn(self, pkmn):
+	disappear_time = datetime.utcfromtimestamp(pkmn['disappear_time']);
+	# Only process if this is a new lured pokestop or if the pokestop's pokemon
+	# has a new disappear time that is greater than the last one.
+	if (pkmn['pokestop_id'] not in self.lured_seen
+			or self.lured_seen[pkmn['pokestop_id']]['disappear_time'] < disappear_time):
+		name = pkmn_name(pkmn['pokemon_id'])
+		pkinfo = {
+			'id': pkmn['pokemon_id'],
+			'name': name,
+			'alert': pkmn_alert_text(name),
+			'gmaps_link': gmaps_link(pkmn['latitude'], pkmn['longitude']),
+			'time_text': pkmn_time_text(disappear_time),
+			'disappear_time': disappear_time
+			}
+		self.lured_seen[pkmn['pokestop_id']] = pkinfo
+		if self.notify_list[name] != "True" :
+			log.info(name + " notification was not triggered because alarm is disabled.")
+		elif disappear_time < datetime.utcnow() :
+			log.info(name + " notification was not triggered because time_left had passed.")
+		else:
+			log.info(name + " notication was triggered!")
+			for alarm in self.alarms:
+				alarm.pokemon_alert(pkinfo)
+		if len(self.lured_seen) > 10000:
+			self.clear_stale(lured=True);

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -39,15 +39,56 @@ class Alarm_Manager:
 				else:
 					log.info("Alarm not activated: " + alarm['type'] + " because value not set to \"True\"")
 
-	#Send a notification to alarms about a found pokemon
-	def trigger_pkmn(self, pkmn):
-		if 'encounter_id' in pkmn:
-			trigger_normal_pkmn(self, pkmn)
-		elif 'pokestop_id' in pkmn:
-			trigger_lured_pkmn(self, pkmn)
-		else:
-			raise ValueError("Pokemon is not normal nor lured.")
+        def trigger_normal_pkmn(self, pkmn):
+                if pkmn['encounter_id'] not in self.seen:
+                        name = pkmn_name(pkmn['pokemon_id'])
+                        disappear_time = datetime.utcfromtimestamp(pkmn['disappear_time']);
+                        pkinfo = {
+                                'id': pkmn['pokemon_id'],
+                                'name': name,
+                                'alert': pkmn_alert_text(name),
+                                'gmaps_link': gmaps_link(pkmn['latitude'], pkmn['longitude']),
+                                'time_text': pkmn_time_text(disappear_time),
+                                'disappear_time': disappear_time
+                                }
+                        self.seen[pkmn['encounter_id']] = pkinfo
+                        if self.notify_list[name] != "True" :
+                                log.info(name + " notification was not triggered because alarm is disabled.")
+                        elif disappear_time < datetime.utcnow() :
+                                log.info(name + " notification was not triggered because time_left had passed.")
+                        else:
+                                log.info(name + " notication was triggered!")
+                                for alarm in self.alarms:
+                                        alarm.pokemon_alert(pkinfo)
+                        if len(self.seen) > 10000 :
+                                self.clear_stale(normal=True);
 
+        def trigger_lured_pkmn(self, pkmn):
+                disappear_time = datetime.utcfromtimestamp(pkmn['disappear_time']);
+                # Only process if this is a new lured pokestop or if the pokestop's pokemon
+                # has a new disappear time that is greater than the last one.
+                if (pkmn['pokestop_id'] not in self.lured_seen
+                                or self.lured_seen[pkmn['pokestop_id']]['disappear_time'] < disappear_time):
+                        name = pkmn_name(pkmn['pokemon_id'])
+                        pkinfo = {
+                                'id': pkmn['pokemon_id'],
+                                'name': name,
+                                'alert': pkmn_alert_text(name),
+                                'gmaps_link': gmaps_link(pkmn['latitude'], pkmn['longitude']),
+                                'time_text': pkmn_time_text(disappear_time),
+                                'disappear_time': disappear_time
+                                }
+                        self.lured_seen[pkmn['pokestop_id']] = pkinfo
+                        if self.notify_list[name] != "True" :
+                                log.info(name + " notification was not triggered because alarm is disabled.")
+                        elif disappear_time < datetime.utcnow() :
+                                log.info(name + " notification was not triggered because time_left had passed.")
+                        else:
+                                log.info(name + " notication was triggered!")
+                                for alarm in self.alarms:
+                                        alarm.pokemon_alert(pkinfo)
+                        if len(self.lured_seen) > 10000:
+                                self.clear_stale(lured=True);
 
 	#Send a notication about pokemon lure found
 	def notify_lures(self, lures):
@@ -73,54 +114,3 @@ class Alarm_Manager:
 					old.append(id)
 			for id in old:
 				del self.lured_seen[id]
-
-def trigger_normal_pkmn(self, pkmn):
-	if pkmn['encounter_id'] not in self.seen:
-		name = pkmn_name(pkmn['pokemon_id'])
-		disappear_time = datetime.utcfromtimestamp(pkmn['disappear_time']);
-		pkinfo = {
-			'id': pkmn['pokemon_id'],
-			'name': name,
-			'alert': pkmn_alert_text(name),
-			'gmaps_link': gmaps_link(pkmn['latitude'], pkmn['longitude']),
-			'time_text': pkmn_time_text(disappear_time),
-			'disappear_time': disappear_time
-			}
-		self.seen[pkmn['encounter_id']] = pkinfo
-		if self.notify_list[name] != "True" :
-			log.info(name + " notification was not triggered because alarm is disabled.")
-		elif disappear_time < datetime.utcnow() :
-			log.info(name + " notification was not triggered because time_left had passed.")
-		else:
-			log.info(name + " notication was triggered!")
-			for alarm in self.alarms:
-				alarm.pokemon_alert(pkinfo)
-		if len(self.seen) > 10000 :
-			self.clear_stale(normal=True);
-
-def trigger_lured_pkmn(self, pkmn):
-	disappear_time = datetime.utcfromtimestamp(pkmn['disappear_time']);
-	# Only process if this is a new lured pokestop or if the pokestop's pokemon
-	# has a new disappear time that is greater than the last one.
-	if (pkmn['pokestop_id'] not in self.lured_seen
-			or self.lured_seen[pkmn['pokestop_id']]['disappear_time'] < disappear_time):
-		name = pkmn_name(pkmn['pokemon_id'])
-		pkinfo = {
-			'id': pkmn['pokemon_id'],
-			'name': name,
-			'alert': pkmn_alert_text(name),
-			'gmaps_link': gmaps_link(pkmn['latitude'], pkmn['longitude']),
-			'time_text': pkmn_time_text(disappear_time),
-			'disappear_time': disappear_time
-			}
-		self.lured_seen[pkmn['pokestop_id']] = pkinfo
-		if self.notify_list[name] != "True" :
-			log.info(name + " notification was not triggered because alarm is disabled.")
-		elif disappear_time < datetime.utcnow() :
-			log.info(name + " notification was not triggered because time_left had passed.")
-		else:
-			log.info(name + " notication was triggered!")
-			for alarm in self.alarms:
-				alarm.pokemon_alert(pkinfo)
-		if len(self.lured_seen) > 10000:
-			self.clear_stale(lured=True);

--- a/runwebhook.py
+++ b/runwebhook.py
@@ -19,9 +19,13 @@ def trigger_alert():
 	log.debug("POST request response has been triggered.")
 	data = json.loads(request.data)
 	if data['type'] == 'pokemon' :
-		log.debug("POST request is  a pokemon.")
+		log.debug("POST request is a pokemon.")
 		pkmn = data['message']
-		alerts.trigger_pkmn(pkmn)			
+		alerts.trigger_normal_pkmn(pkmn)			
+        elif data['type'] == 'lured_pokemon' :
+		log.debug("POST request is a lured pokemon.")
+		pkmn = data['message']
+		alerts.trigger_lured_pkmn(pkmn)			
 	elif data['type'] == 'pokestop' : 
 		log.debug("Pokestop notifications not yet implimented.")
 		#do nothing


### PR DESCRIPTION
I implemented lured pokemon notifications by creating a new webhook in PokemonGo-Map. See this PR https://github.com/AHAAAAAAA/PokemonGo-Map/pull/2987.

To test, please use [this branch](https://github.com/hhu94/PokemonGo-Map/tree/lured-pokemon-webhook) of my PokemonGo-Map fork.

Obviously this implementation is dependent on whether my PokemonGo-Map pull request is merged as is, but it shouldn't be difficult to tweak the implementation if the webhook data ends up having a different structure.