### PR TITLE
Add ability to filter notifications from lured Pokestops

### DIFF
--- a/alarms.json.default
+++ b/alarms.json.default
@@ -30,7 +30,7 @@
 			"type": "pushover",
 			"app_token": "YOUR_APP_TOKEN",
 			"user_key": "YOUR_USER_KEY"
-        }
+		}
 	],
 	"pokemon":{
 		"Bulbasaur":"False",

--- a/alarms/__init__.py
+++ b/alarms/__init__.py
@@ -2,11 +2,12 @@
 # -*- coding: utf-8 -*-
 
 config = {
-    'LOCALE': 'en',
-    'LOCALES_DIR': 'locales',
-    'ROOT_PATH': '',
+	'LOCALE': 'en',
+	'LOCALES_DIR': 'locales',
+	'ROOT_PATH': '',
 	'HOST':'127.0.0.1',
 	'PORT':'4000',
+	'SKIP_LURED':False
 }
 
 from utils import  *

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -83,7 +83,10 @@ class Alarm_Manager(Thread):
 		if pkmn_id not in self.notify_list:
 			log.info(name + " ignored: notify not enabled.")
 			return
-		
+		#Check if we are ignoring lured Pokemon
+		if config['SKIP_LURED'] and pkmn['is_lured']:
+			log.info(name + " ignored: lured pokemon not enabled.")
+			return
 		#Check if the Pokemon is outside of notify range
 		lat = pkmn['latitude']
 		lng = pkmn['longitude']

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -35,6 +35,7 @@ def set_config(root_path):
 	parser.add_argument('-l', '--location', type=parse_unicode, help='Location, can be an address or coordinates')
 	parser.add_argument('-L', '--locale', help='Locale for Pokemon names: default en, check locale folder for more options', default='en')
 	parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
+	parser.add_argument('-sl', '--skip_lured', help='Do not alert for a lured Pokemon.', action='store_true')
 	parser.set_defaults(DEBUG=False)
 	
 	args = parser.parse_args()
@@ -44,6 +45,7 @@ def set_config(root_path):
 	config['PORT'] = args.port
 	config['LOCALE'] = args.locale
 	config['DEBUG'] = args.debug
+	config['SKIP_LURED'] = args.skip_lured
 	
 	if args.location:
 		config['LOCATION'] =  get_pos_by_name(args.location)


### PR DESCRIPTION
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->


## Description
<!--- Describe your changes in detail -->
Allows users to set the -sl flag to skip lured pokemon. This is useful because lured pokemon often spawn far distances from the user's search area, or have very short times. Some users would like the ability to skip notifications for them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Made code changes and ran webhook for two days, monitoring output and logging. No errors, when flag was set, pokemon that were lured were not notified for. When flag was absent, lured pokemon were notified as intended.

<!--- Include details of your testing environment, and the tests you ran to -->
Tested running with latest develop on PokemonGo-Map/PokemonGo-Map on a linux platform. Tested for 2 days.
<!--- see how your change affects other areas of the code, etc. -->
Change falls inline with current code, also updates small parts of the code to fall in line with the rest of the code style of the project

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) describing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

