### PR TITLE
support for ifttt maker channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The following services are currently supported:
 * Twilio (SMS)
 * Telegram 
 * Pushover
+* IFTTT Maker Channel
 
 If you are experiencing issues with the alarm or would like to see new features, please open a ticket here on github. 
 

--- a/alarms.json.default
+++ b/alarms.json.default
@@ -42,8 +42,8 @@
 		{
 			"active": "False",
 			"type":"ifttt",
-			"api_key":"bryeq0dWmIgBlDxUiBWaQ3",
-			"event":"pokemon_found",
+			"api_key":"YOUR_MAKER_KEY",
+			"event":"YOUR_EVENT_NAME",
 			"value1":"A wild <pkmn> appeared",
 			"value2":"at the address <addr>",
 			"value3":"with <time_left> left"

--- a/alarms.json.default
+++ b/alarms.json.default
@@ -20,7 +20,7 @@
 			"to_number":"YOUR_TO_NUM"
 		},
 		{
-			"active": "True",
+			"active": "False",
 			"type":"telegram",
 			"bot_token":"YOUR_BOT_TOKEN",
 			"chat_id":"YOUR_CHAT_ID"
@@ -38,7 +38,16 @@
 			"access_secret": "YOUR_ACCESS_SECRET",
 			"consumer_key": "YOUR_CONSUMER_KEY",
 			"consumer_secret": "YOUR_CONSUMER_SECRET"
-        }
+        },
+		{
+			"active": "False",
+			"type":"ifttt",
+			"api_key":"bryeq0dWmIgBlDxUiBWaQ3",
+			"event":"pokemon_found",
+			"value1":"A wild <pkmn> appeared",
+			"value2":"at the address <addr>",
+			"value3":"with <time_left> left"
+		}
 	],
 	"pokemon":{
 		"Bulbasaur":"False",

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -15,6 +15,7 @@ from pushbullet_alarm import Pushbullet_Alarm
 from twilio_alarm import Twilio_Alarm
 from telegram_alarm import Telegram_Alarm
 from pushover_alarm import Pushover_Alarm
+from ifttt_alarm import IFTTT_Alarm
 from utils import *
 
 class Alarm_Manager(Thread):
@@ -51,6 +52,8 @@ class Alarm_Manager(Thread):
 					elif alarm['type'] == 'twitter' :
 						from Twitter import Twitter_Alarm
 						self.alarms.append(Twitter_Alarm(alarm))
+					elif alarm['type'] == 'ifttt' :
+						self.alarms.append(IFTTT_Alarm(alarm))
 					else:
 						log.info("Alarm type not found: " + alarm['type'])
 				else:

--- a/alarms/ifttt_alarm.py
+++ b/alarms/ifttt_alarm.py
@@ -1,0 +1,45 @@
+import logging
+
+import httplib, urllib
+from alarm import Alarm
+from utils import *
+
+log = logging.getLogger(__name__)
+
+class IFTTT_Alarm(Alarm):
+    
+    def __init__(self, settings):
+        self.api_key = settings['api_key']
+        self.event = settings['event']
+        self.connect()
+        self.value1 = settings.get('value1', "<pkmn>")
+        self.value2 = settings.get('value2', "<addr>")
+        self.value3 = settings.get('value3', "<time_left>")
+        log.info("IFTTT Alarm intialized")
+    
+    def connect(self):
+        pass
+
+    def pokemon_alert(self, pkinfo):
+        args = {
+            'value1': replace(self.value1, pkinfo),
+            'value2': replace(self.value2, pkinfo),
+            'value3': replace(self.value3, pkinfo)
+        }
+        try_sending(log, self.connect, "IFTTT", self.send_ifttt, args)
+    
+    def send_ifttt(self, value1 = None, value2 = None, value3 = None):		
+		##Establish connection
+		connection = httplib.HTTPSConnection("maker.ifttt.com:443", timeout=10)
+		
+		payload = {"value1": value1, 
+				"value2": value2, 
+				"value3": value3}
+		
+		connection.request("POST", "/trigger/{e}/with/key/{k}/".format(e=self.event,k=self.api_key), urllib.urlencode(payload), 
+			{"Content-Type": "application/x-www-form-urlencoded"})
+		r = connection.getresponse()
+		if r.status != 200:
+			raise httplib.HTTPException("Response not 200")
+		
+        


### PR DESCRIPTION
Note: IFTTT maker channel uses a very simple http request, this code is mostly a copy of the pushover alarm code.


## Description
Added support for IFTTT Maker Channel

## How Has This Been Tested?
Tested on Windows running PokemonGo-Map and using the IFTTT recipe here:
https://ifttt.com/recipes/453460-ifttt-support-test-for-pokealarm

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
In your IFTTT account, connect to the Maker channel. You will be given an API key by IFTTT. Create a new recipe and give it an event name. Make use of the ingredients "value1", "value2", and "value3" in your IFTTT recipe. Note: you cannot change the names of these 3 values, they are set by IFTTT and three is the maximum number available. In PokeAlarm you can edit the config file to enable IFTTT, enter your key and event name, and customize the contents of value1, value2, and value3.

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

