### PR TITLE
Slack: Add static maps of Pokemon locations

### DIFF
--- a/alarms.json.default
+++ b/alarms.json.default
@@ -9,7 +9,16 @@
 			"active": "False",
 			"type":"slack",
 			"api_key":"YOUR_API_KEY",
-			"channel":"#general"
+			"channel":"#general",
+			"staticmap":{
+				"enabled":"True",
+				"width":"300",
+				"height":"100",
+				"far_zoom":"14",
+				"far_maptype":"roadmap",
+				"close_zoom":"16",
+				"close_maptype":"hybrid"
+			}
 		},
 		{
 			"active": "False",

--- a/alarms/Slack/slack_alarm.py
+++ b/alarms/Slack/slack_alarm.py
@@ -64,13 +64,33 @@ class Slack_Alarm(Alarm):
 		return channel
 
 	#Post a message to channel
-	def post_message(self, channel, username, text, icon_url=None):
-		args = {
+	def post_message(self, channel, username, text, icon_url=None, img=None):
+		if img is not None:
+			args = {
 			'channel': self.get_channel(channel),
 			'username': username,
 			'text': text,
-			'icon_url': icon_url
+			'icon_url': icon_url,
+			'attachments': [
+				{
+					'fallback': 'LocationFar',
+					'image_url': img['far']
+				},
+				{
+					'fallback': 'LocationClose',
+					'image_url': img['close']
+				}
+			]
 		}
+		
+		if img is None:
+			args = {
+				'channel': self.get_channel(channel),
+				'username': username,
+				'text': text,
+				'icon_url': icon_url
+			}
+		
 		try_sending(log, self.connect, "Slack", self.client.chat.post_message, args)
 		
 	
@@ -80,5 +100,7 @@ class Slack_Alarm(Alarm):
 		username = replace(self.username, pkinfo),
 		text = '<{}|{}> {}'.format(replace(self.url, pkinfo),  replace(self.title, pkinfo) , replace(self.body, pkinfo)),
 		icon_url = 'https://raw.githubusercontent.com/PokemonGoMap/PokemonGo-Map/develop/static/icons/{}.png'.format(pkinfo['id'])
-		self.post_message(channel, username, text, icon_url)
+		img_far = replace('https://maps.googleapis.com/maps/api/staticmap?center=<lat>,<lng>&zoom=14&size=300x100&maptype=roadmap&markers=color:red%7C<lat>,<lng>', pkinfo)
+		img_close = replace('https://maps.googleapis.com/maps/api/staticmap?center=<lat>,<lng>&zoom=16&size=300x100&maptype=roadmap&markers=color:red%7C<lat>,<lng>&maptype=satellite', pkinfo)
+		self.post_message(channel, username, text, icon_url, {'far': img_far, 'close': img_close})
 		


### PR DESCRIPTION
## Note
I'm not familiar with Git or Python, but I wanted to make this change.  Please let me know if there's anything I can improve or if I need to do this pull request differently

## Description
Added two static maps to each slack post to enable users to see what area the Pokemon is in without having to open Google maps.  The map scanner I used was extremely large, and most notifications were not close to me.  It was a pain to have to click on each Google map link to see if it was close.

The "location" argument works nicely if you're the sole user.  But, when multiple users are using your channel, it's not feasible because there is not mechanism (yet) to track each individual user's location.

## How Has This Been Tested?
I ran the alarm both with and without the static map.  I also tested various configuration changes to verify that it handles these optional settings correctly

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/4174452/17651718/b06a0d56-6232-11e6-872d-da50fabaa09a.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
TBD

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
