### PR TITLE
[Fix] Typo in parameter to stick to the wiki

### DIFF
--- a/alarms/Twitter/twitter_alarm.py
+++ b/alarms/Twitter/twitter_alarm.py
@@ -20,7 +20,7 @@ class Twitter_Alarm(Alarm):
 		self.token_key = settings['access_secret']
 		self.con_secret = settings['consumer_key']
 		self.con_secret_key = settings['consumer_secret']
-		self.status = settings.get('status', "A wild <pkmn> has appeared! Available until <24h_time> (<time_left>). <gmaps>")
+		self.status = settings.get('message', "A wild <pkmn> has appeared! Available until <24h_time> (<time_left>). <gmaps>")
 		self.connect()
 		log.info("Twitter Alarm intialized.")
 		self.client.statuses.update(status="%s: PokeAlarm has intialized!" % datetime.utcnow().strftime("%H:%M:%S"))


### PR DESCRIPTION
## Description
On the wiki ( https://github.com/kvangent/PokeAlarm/wiki/Twitter ), it said : "Optional Parameters : message". Tried it and didnt work.
The fault to the code.

## How Has This Been Tested?
My server

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
Dont need

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

