### PR TITLE
[Enhancement] Add switch to disable first tweet at initialization

### DIFF
--- a/alarms/Twitter/twitter_alarm.py
+++ b/alarms/Twitter/twitter_alarm.py
@@ -21,9 +21,11 @@ class Twitter_Alarm(Alarm):
 		self.con_secret = settings['consumer_key']
 		self.con_secret_key = settings['consumer_secret']
 		self.status = settings.get('status', "A wild <pkmn> has appeared! Available until <24h_time> (<time_left>). <gmaps>")
+		self.tweet_at_init = settings.get('tweet_at_init', "True")
 		self.connect()
 		log.info("Twitter Alarm intialized.")
-		self.client.statuses.update(status="%s: PokeAlarm has intialized!" % datetime.utcnow().strftime("%H:%M:%S"))
+		if self.tweet_at_init != "False" :
+			self.client.statuses.update(status="%s: PokeAlarm has intialized!" % datetime.utcnow().strftime("%H:%M:%S"))
 	
 	#Establish connection with Twitter
 	def connect(self):

--- a/alarms/Twitter/twitter_alarm.py
+++ b/alarms/Twitter/twitter_alarm.py
@@ -21,10 +21,10 @@ class Twitter_Alarm(Alarm):
 		self.con_secret = settings['consumer_key']
 		self.con_secret_key = settings['consumer_secret']
 		self.status = settings.get('status', "A wild <pkmn> has appeared! Available until <24h_time> (<time_left>). <gmaps>")
-		self.tweet_at_init = settings.get('tweet_at_init', "True")
+		self.startup_message = settings.get('startup_message', "True")
 		self.connect()
 		log.info("Twitter Alarm intialized.")
-		if self.tweet_at_init != "False" :
+		if self.startup_message != "False" :
 			self.client.statuses.update(status="%s: PokeAlarm has intialized!" % datetime.utcnow().strftime("%H:%M:%S"))
 	
 	#Establish connection with Twitter

--- a/alarms/Twitter/twitter_alarm.py
+++ b/alarms/Twitter/twitter_alarm.py
@@ -25,7 +25,7 @@ class Twitter_Alarm(Alarm):
 		self.connect()
 		log.info("Twitter Alarm intialized.")
 		if parse_boolean(self.startup_message):
-			self.client.statuses.update(status="%s: PokeAlarm has intialized!" % datetime.utcnow().strftime("%H:%M:%S"))
+			self.client.statuses.update(status="%s: PokeAlarm has intialized!" % datetime.now().strftime("%H:%M:%S"))
 	
 	#Establish connection with Twitter
 	def connect(self):

--- a/alarms/Twitter/twitter_alarm.py
+++ b/alarms/Twitter/twitter_alarm.py
@@ -24,7 +24,7 @@ class Twitter_Alarm(Alarm):
 		self.startup_message = settings.get('startup_message', "True")
 		self.connect()
 		log.info("Twitter Alarm intialized.")
-		if self.startup_message != "False" :
+		if parse_boolean(self.startup_message):
 			self.client.statuses.update(status="%s: PokeAlarm has intialized!" % datetime.utcnow().strftime("%H:%M:%S"))
 	
 	#Establish connection with Twitter


### PR DESCRIPTION
## Description
Add optional setting `startup_message` for Twitter module.
Default on "True".
If set to "False", it prevent the Alarm from tweeting "PokeAlarm has intialized!" at startup

## How Has This Been Tested?
With my twitter, 2 times and it work.

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/12863317/17834678/93ef0d2a-674b-11e6-856e-be2b1c7c87cf.png)

![image](https://cloud.githubusercontent.com/assets/12863317/17834626/037b9c64-674a-11e6-8db0-c885e43596da.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
Add to the optionnal options something like : 
```
`startup_message` | `Trigger a tweet at initialization` | `True`
```
##### Ps: I'm bad at markdown

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

