### PR TITLE
Specify a different config file on the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This is a problem with the PokemonGo-Map sending an object with UTC time listed 
 
 3. Run pip to install requirements `pip install -r requirements.txt`
 
-4. Copy alarms.json.default and rename it to alarms.json. Edit the file (Windows Users: NOT with notepad) with your configuration settings. Make sure to change the pokemon you want to be alerted to "True". Each alarm configuration will be added to the wiki shortly. All the fields are required except for the 'name' field - it can be left blank or not included in the config at all. You can also add multple of the same alarm type.
+4. Copy alarms.json.default and rename it to alarms.json. Edit the file (Windows Users: NOT with notepad) with your configuration settings. Make sure to change the pokemon you want to be alerted to "True". Each alarm configuration will be added to the wiki shortly. All the fields are required except for the 'name' field - it can be left blank or not included in the config at all. You can also add multple of the same alarm type.  You can specify a different configuration file with `-cn <config_file.json>`.
 
 5. Start the webhook server with `python runwebhook.py`. You should receive a notification if your alarm is set up correctly. You can specify a host and port with `-H HOST -P PORT`. The default is a host of 127.0.0.1 and port of 4000. This is the port that the webhook will listen on. The port number MUST be different to what you run your PokemonGo-Map server on!
 

--- a/alarms/__init__.py
+++ b/alarms/__init__.py
@@ -7,7 +7,8 @@ config = {
 	'ROOT_PATH': '',
 	'HOST':'127.0.0.1',
 	'PORT':'4000',
-	'SKIP_LURED':False
+	'SKIP_LURED':False,
+        'CONFIG_FILE': 'alarms.json'
 }
 
 from utils import  *

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -20,7 +20,7 @@ class Alarm_Manager(Thread):
 		super(Alarm_Manager, self).__init__()
 		#Import settings from Alarms.json
 		filepath = config['ROOT_PATH']
-		with open(os.path.join(filepath, 'alarms.json')) as file:
+		with open(os.path.join(filepath, config['CONFIG_FILE'])) as file:
 			settings = json.load(file)
 			alarm_settings = settings["alarms"]
 			self.notify_list = make_notify_list(settings["pokemon"])

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -37,6 +37,7 @@ def set_config(root_path):
 	parser.add_argument('-L', '--locale', help='Locale for Pokemon names: default en, check locale folder for more options', default='en')
 	parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
 	parser.add_argument('-gf', '--geofence', help='Specify a file of coordinates, limiting alerts to within this area')
+	parser.add_argument('-cn', '--config', help='Config file. default: alarms.json', default='alarms.json')
 	parser.set_defaults(DEBUG=False)
 	
 	args = parser.parse_args()
@@ -46,6 +47,7 @@ def set_config(root_path):
 	config['PORT'] = args.port
 	config['LOCALE'] = args.locale
 	config['DEBUG'] = args.debug
+        config['CONFIG_FILE'] = args.config
 	
 	if args.location:
 		config['LOCATION'] =  get_pos_by_name(args.location)


### PR DESCRIPTION
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->


## Description
<!--- Describe your changes in detail -->
Added an option `-cn` or `--config` to the CLI that allows a different configuration file to be specified.  This is useful for people that to run multiple instances of PokeAlarm with different configuration files.  This is inspired from https://github.com/PokemonGoMap/PokemonGo-Map/pull/912.  If not config file is provided, the default alarms.json is used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested running locally with specifying a file and then running without specifying.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) desciribing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->
README.txt was updated.  I can update the wiki as well if needed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

