### PR TITLE
Add read only Geofence/Location API map

### DIFF
--- a/alarms/geofence.py
+++ b/alarms/geofence.py
@@ -7,6 +7,9 @@ import sys
 import csv
 from sympy.geometry import Point, Polygon
 from sympy.core.cache import clear_cache
+from urllib import urlencode
+
+from . import config
 
 class Geofence(object):	
 
@@ -40,4 +43,36 @@ class Geofence(object):
 		rtn = self.polygon.encloses_point(Point(x,y, evaluate=False))
 		clear_cache()
 		return rtn
+
+# Gets the url of a static google map of the currently set geofence and/or location 
+def get_geofence_static_map():
+	geofence = config.get('GEOFENCE')
+	location = config.get('LOCATION')
+	api_key = config.get('API_KEY')
+	if geofence is None and location is None: # No location or Geofence set
+		return False
+
+	url_string = "https://maps.googleapis.com/maps/api/staticmap?size=600x600&maptype=roadmap"
+
+	#Draw polygon
+	if geofence is not None:
+		poly_string = "color:0x0000ff80|fillcolor:0x00000022|weight:3"
+		vert = geofence.polygon.vertices
+		for pt_lat, pt_lng in vert:
+			poly_string = poly_string + '|{!s},{!s}'.format(float(pt_lat),float(pt_lng))
+		poly_string = poly_string + '|{!s},{!s}'.format(float(vert[0][0]), float(vert[0][1])) # Close polygon with first point
+		url_string = url_string + '&' + urlencode({'path':poly_string})
+
+	#Draw location marker
+	if location is not None:
+		marker_string = 'fillcolor:blue|{!s},{!s}'.format(location[0], location[1])
+		url_string = url_string + '&' + urlencode({'markers':marker_string})
+
+	#Include API Key if specified
+	if api_key is not None:
+		url_string = url_string + "&key={}".format(api_key)
+	else:
+		print "API KEY not provided"
+
+	return url_string
 

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -247,32 +247,6 @@ def get_static_map_url(settings):
 	log.debug("Static Map URL: " + map)
 	return map
 
-# Gets the url of the currently set geofence and/or location 
-def get_geofence_static_map():
-	if 'GEOFENCE' not in config and ('LOCATION' not in config or config['LOCATION'] == None): # No location or Geofence set
-		return False
-
-	url_string = "https://maps.googleapis.com/maps/api/staticmap?size=600x600&maptype=roadmap"
-
-	#Draw polygon
-	if 'GEOFENCE' in config:
-		poly_string = "&path=color%3A0x0000ff80%7Cfillcolor%3A0x00000022%7Cweight%3A3"
-		vert = config['GEOFENCE'].polygon.vertices
-		for pt_lat, pt_lng in vert:
-			poly_string = poly_string + "|" + str(float(pt_lat)) + "," + str(float(pt_lng))
-		poly_string = poly_string + "|" + str(float(vert[0][0])) + "," + str(float(vert[0][1])) # Close polygon with first point
-		url_string = url_string + poly_string
-
-	#Draw point
-	if 'LOCATION' in config and config['LOCATION'] != None:
-		url_string = url_string + "&markers=color%3Ablue%7C%s,%s" % (config['LOCATION'][0], config['LOCATION'][1])
-
-	#Include API Key is specified
-	if 'API_KEY' in config:
-		url_string = url_string + "&key=" & conf
-
-	return url_string
-
 #Checks is a line contains any subsititions located in args
 def contains_arg(line, args):
 	for word in args:

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -247,6 +247,32 @@ def get_static_map_url(settings):
 	log.debug("Static Map URL: " + map)
 	return map
 
+# Gets the url of the currently set geofence and/or location 
+def get_geofence_static_map():
+	if 'GEOFENCE' not in config and ('LOCATION' not in config or config['LOCATION'] == None): # No location or Geofence set
+		return False
+
+	url_string = "https://maps.googleapis.com/maps/api/staticmap?size=600x600&maptype=roadmap"
+
+	#Draw polygon
+	if 'GEOFENCE' in config:
+		poly_string = "&path=color%3A0x0000ff80%7Cfillcolor%3A0xFFFF0033%7Cweight%3A5"
+		vert = config['GEOFENCE'].polygon.vertices
+		for pt_lat, pt_lng in vert:
+			poly_string = poly_string + "|" + str(float(pt_lat)) + "," + str(float(pt_lng))
+		poly_string = poly_string + "|" + str(float(vert[0][0])) + "," + str(float(vert[0][1])) # Close polygon with first point
+		url_string = url_string + poly_string
+
+	#Draw point
+	if 'LOCATION' in config and config['LOCATION'] != None:
+		url_string = url_string + "&markers=color%3Ablue%7C%s,%s" % (config['LOCATION'][0], config['LOCATION'][1])
+
+	#Include API Key is specified
+	if 'API_KEY' in config:
+		url_string = url_string + "&key=" & conf
+
+	return url_string
+
 #Checks is a line contains any subsititions located in args
 def contains_arg(line, args):
 	for word in args:

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -256,7 +256,7 @@ def get_geofence_static_map():
 
 	#Draw polygon
 	if 'GEOFENCE' in config:
-		poly_string = "&path=color%3A0x0000ff80%7Cfillcolor%3A0xFFFF0033%7Cweight%3A5"
+		poly_string = "&path=color%3A0x0000ff80%7Cfillcolor%3A0x00000022%7Cweight%3A3"
 		vert = config['GEOFENCE'].polygon.vertices
 		for pt_lat, pt_lng in vert:
 			poly_string = poly_string + "|" + str(float(pt_lat)) + "," + str(float(pt_lng))

--- a/runwebhook.py
+++ b/runwebhook.py
@@ -18,6 +18,7 @@ import Queue
 from alarms import config, set_config
 from alarms.alarm_manager import Alarm_Manager
 from alarms.utils import get_pos_by_name
+from alarms.utils import get_geofence_static_map
 
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -47,6 +48,14 @@ def update_location():
 		abort(400)
 	log.info("Location updated via POST request!")
 	return "Location changed to : %s" % config['LOCATION']
+
+@app.route('/geofence/',methods=['GET'])
+def return_geofence():
+	geofence_url = get_geofence_static_map()
+	if geofence_url != False:
+		return '<img src="%s">' % (geofence_url)
+	else:
+		return 'No location or geofence set'
 
 if __name__ == '__main__':
 	#Parse arguments and set up config

--- a/runwebhook.py
+++ b/runwebhook.py
@@ -18,7 +18,7 @@ import Queue
 from alarms import config, set_config
 from alarms.alarm_manager import Alarm_Manager
 from alarms.utils import get_pos_by_name
-from alarms.utils import get_geofence_static_map
+from alarms.geofence import get_geofence_static_map
 
 reload(sys)
 sys.setdefaultencoding('utf8')
@@ -53,7 +53,7 @@ def update_location():
 def return_geofence():
 	geofence_url = get_geofence_static_map()
 	if geofence_url != False:
-		return '<img src="%s">' % (geofence_url)
+		return '<img src="{}">'.format(geofence_url)
 	else:
 		return 'No location or geofence set'
 


### PR DESCRIPTION
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->


## Description
Add a simple ability to get a map of the current geofence and location.

## How Has This Been Tested?
Tested on y Ubuntu 16.04 install
Tried several different command line switches

## Screenshots (if appropriate):
<img width="586" alt="screen shot 2016-08-25 at 12 01 31 am" src="https://cloud.githubusercontent.com/assets/4873772/17957598/ae563c5a-6a58-11e6-9c5c-2b6070d1c81a.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
API (section)
http://ip_address:port/geofence/ - Returns a static google map of the current location and geofence

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
