### PR TITLE
Fixed bug in debug log formatting

### DIFF
--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -103,7 +103,7 @@ class Alarm_Manager(Thread):
 		dist = get_dist([lat, lng])
 		if dist >= self.notify_list[pkmn_id]:
 			log.info(name + " ignored: outside range")
-			log.debug("Pokemon must be less than %f, but was %f." % (self.notify_list[pkmn_id]), dist)
+			log.debug('Pokemon must be less than {:f}, but was {:f}.'.format(self.notify_list[pkmn_id], dist))
 			return
         
 		#Check if the Pokemon is in the geofence


### PR DESCRIPTION
## Description
Latest master contained a buggy debug log format line that caused the program to throw an exception when it was out of range (as defined in `alarms.json` given a proper location on the commandline:
```
2016-08-26 10:23:42,296 [     alarm_manager] [   INFO] NidoranÔÖÇ ignored: outside range
Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\Python27\lib\threading.py", line 801, in __bootstrap_inner
    self.run()
  File "c:\POGO\PokeAlarm\alarms\alarm_manager.py", line 73, in run
    self.trigger_pkmn(data['message'])
  File "c:\POGO\PokeAlarm\alarms\alarm_manager.py", line 106, in trigger_pkmn
    log.debug("Pokemon must be less than %f, but was %f." % (self.notify_list[pkmn_id]), dist)
TypeError: not enough arguments for format string
```
This has been fixed.

## How Has This Been Tested?
No more exceptions on local machine.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

