### PR TITLE
Git ignore all user configuration and startup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
-alarms.json
 coords.txt
+
+# ignore multiple configuration files and possible startup scripts
+/*.json
+/*.bat
+/*.sh


### PR DESCRIPTION
## Description
I have several alarms-*.json files and .bat files in my PokeAlarm directory to quickly launch different setups. These files should not be committed to Git.

## How Has This Been Tested?
Git doesn't see these files any more. ;)

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Project setup modification

## Wiki Update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
