### PR TITLE
Support sending notifications in a specified timezone.

### DIFF
--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -215,7 +215,7 @@ def get_timestamps(t):
 	disappear_time = disappear_time.replace(tzinfo=pytz.utc).astimezone(config.get("TIMEZONE"))
 	time_left = "%dm %ds" % (m, s)
 	time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower() + disappear_time.strftime(" %Z")
-	time_24 = disappear_time.strftime("%H:%M:%S%Z")
+	time_24 = disappear_time.strftime("%H:%M:%S %Z")
 	return (time_left, time_12, time_24)
 	
 #########################################################################

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -10,6 +10,7 @@ import time
 import sys
 import re
 import googlemaps
+import pytz
 from glob import glob
 from datetime import datetime, timedelta
 from math import radians, sin, cos, atan2, sqrt
@@ -77,6 +78,7 @@ def set_config(root_path):
 	parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true',  default=False)
 	parser.add_argument('-gf', '--geofence', help='Specify a file of coordinates, limiting alerts to within this area')
 	parser.add_argument('-tl', '--timelimit', type=int, help='Minimum number of seconds remaining on a pokemon to notify', default=0)
+	parser.add_argument('-tz', '--timezone', help='Timezone used for notifications.  Default: UTC', default='UTC')
 	
 	args = parser.parse_args()
 	
@@ -97,6 +99,13 @@ def set_config(root_path):
 	
 	if args.geofence:
 		config['GEOFENCE'] = Geofence(os.path.join(root_path, args.geofence))
+
+	try:
+		config['TIMEZONE'] = pytz.timezone(args.timezone)
+		log.info("Timezone set to: %s" % args.timezone)
+	except pytz.exceptions.UnknownTimeZoneError:
+		log.error("Invalid timezone. For a list of valid timezones, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones")
+		sys.exit(0)
 		
 	config['REV_LOC'] = False
 	config['DM_WALK'] = False
@@ -203,9 +212,10 @@ def get_timestamps(t):
 	(h, m) = divmod(m, 60)
 	d = timedelta(hours = h, minutes = m, seconds = s)
 	disappear_time = datetime.now() + d
+        disappear_time = disappear_time.replace(tzinfo=pytz.utc).astimezone(config.get("TIMEZONE"))
 	time_left = "%dm %ds" % (m, s)
-	time_12 = disappear_time.strftime("%I:%M") + disappear_time.strftime("%p").lower()
-	time_24 = disappear_time.strftime("%H:%M:%S")
+	time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower() + disappear_time.strftime(" %Z")
+	time_24 = disappear_time.strftime("%H:%M:%S%Z")
 	return (time_left, time_12, time_24)
 	
 #########################################################################

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -105,7 +105,7 @@ def set_config(root_path):
 		log.info("Timezone set to: %s" % args.timezone)
 	except pytz.exceptions.UnknownTimeZoneError:
 		log.error("Invalid timezone. For a list of valid timezones, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones")
-		sys.exit(0)
+		sys.exit(1)
 		
 	config['REV_LOC'] = False
 	config['DM_WALK'] = False
@@ -212,7 +212,7 @@ def get_timestamps(t):
 	(h, m) = divmod(m, 60)
 	d = timedelta(hours = h, minutes = m, seconds = s)
 	disappear_time = datetime.now() + d
-        disappear_time = disappear_time.replace(tzinfo=pytz.utc).astimezone(config.get("TIMEZONE"))
+	disappear_time = disappear_time.replace(tzinfo=pytz.utc).astimezone(config.get("TIMEZONE"))
 	time_left = "%dm %ds" % (m, s)
 	time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower() + disappear_time.strftime(" %Z")
 	time_24 = disappear_time.strftime("%H:%M:%S%Z")

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -78,7 +78,7 @@ def set_config(root_path):
 	parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true',  default=False)
 	parser.add_argument('-gf', '--geofence', help='Specify a file of coordinates, limiting alerts to within this area')
 	parser.add_argument('-tl', '--timelimit', type=int, help='Minimum number of seconds remaining on a pokemon to notify', default=0)
-	parser.add_argument('-tz', '--timezone', help='Timezone used for notifications.  Default: UTC', default='UTC')
+	parser.add_argument('-tz', '--timezone', help='Timezone used for notifications.  Ex: "America/Los_Angeles"')
 	
 	args = parser.parse_args()
 	
@@ -100,13 +100,14 @@ def set_config(root_path):
 	if args.geofence:
 		config['GEOFENCE'] = Geofence(os.path.join(root_path, args.geofence))
 
-	try:
-		config['TIMEZONE'] = pytz.timezone(args.timezone)
-		log.info("Timezone set to: %s" % args.timezone)
-	except pytz.exceptions.UnknownTimeZoneError:
-		log.error("Invalid timezone. For a list of valid timezones, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones")
-		sys.exit(1)
-		
+	if args.timezone:
+		try:
+			config['TIMEZONE'] = pytz.timezone(args.timezone)
+			log.info("Timezone set to: %s" % args.timezone)
+		except pytz.exceptions.UnknownTimeZoneError:
+			log.error("Invalid timezone. For a list of valid timezones, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones")
+			sys.exit(1)
+
 	config['REV_LOC'] = False
 	config['DM_WALK'] = False
 	config['DM_BIKE'] = False
@@ -211,8 +212,10 @@ def get_timestamps(t):
 	(m, s) = divmod(s, 60)
 	(h, m) = divmod(m, 60)
 	d = timedelta(hours = h, minutes = m, seconds = s)
-	disappear_time = datetime.now() + d
-	disappear_time = disappear_time.replace(tzinfo=pytz.utc).astimezone(config.get("TIMEZONE"))
+	if "TIMEZONE" in config:
+		disappear_time = datetime.now(tz=config.get("TIMEZONE")) + d
+	else:
+		disappear_time = datetime.now() + d
 	time_left = "%dm %ds" % (m, s)
 	time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower() + disappear_time.strftime(" %Z")
 	time_24 = disappear_time.strftime("%H:%M:%S %Z")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gevent==1.1.2
 googlemaps==2.4.4
 s2sphere==0.2.4
 sympy==1.0
+pytz==2016.6.1


### PR DESCRIPTION
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->

## Description
<!--- Describe your changes in detail -->
This adds a new CLI option, -tz or --timezone, that sends notifications in that timezone instead of always using UTC formatted dates.  If an option isn't specified, it defaults to "UTC".  A list of valid timezone strings are available at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

One related minor changes is adding seconds to time_12 to be consistent with time_24.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested specifying a timezone and tested again without.
python runwebhook.py -H 0.0.0.0 -P 4002 --config alarms.TAMARACK.json -k "XXXX" -tz "America/Los_Angeles"

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/4229409/18030487/413c503a-6c6c-11e6-8b22-7ee1f149b458.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) desciribing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
