### PR TITLE
support for different spawnpoint types

### DIFF
--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -173,14 +173,6 @@ class Alarm_Manager(Thread):
 			'addinfo': get_addinfo(pkmn.get('addinfo',0))
 		}
 		pkmn_info = self.optional_arguments(pkmn_info)
-
-		#Check if the Pokemon will be back after a hidden phase
-		#Addinfo values: 1=2x15 point, 2=1x60h2 point, 3=1x60h3 point, 4=1x60h23 point, only needs to be added, if scanned before the break
-		addinfo = pkmn.get('addinfo',0)
-		reappear_texts = ('','\n15m later back for 15m.', '\n15m later back for 30m.', '\n30m later back for 15m.')
-		reappear_ind = (0, 1, 2, 1, 3)
-		pkmn_info['addinfo'] = reappear_texts[reappear_ind[addinfo]]
-
 		for alarm in self.alarms:
 			alarm.pokemon_alert(pkmn_info)
 

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -170,7 +170,7 @@ class Alarm_Manager(Thread):
 			'12h_time': timestamps[1],
 			'24h_time': timestamps[2],
 			'dir': get_dir(lat,lng),
-			'addinfo': get_addinfo(pkmn.get('addinfo',0))
+			'respawn_text': get_respawn_text(pkmn.get('respawn_info', 0))
 		}
 		pkmn_info = self.optional_arguments(pkmn_info)
 		for alarm in self.alarms:

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -155,7 +155,7 @@ class Alarm_Manager(Thread):
 			if config['GEOFENCE'].contains(lat,lng) is not True:
 				log.info(name + " ignored: outside geofence")
 				return
-				
+
 		#Trigger the notifcations
 		log.info(name + " notication was triggered!")
 		timestamps = get_timestamps(dissapear_time)
@@ -169,10 +169,18 @@ class Alarm_Manager(Thread):
 			'time_left': timestamps[0],
 			'12h_time': timestamps[1],
 			'24h_time': timestamps[2],
-			'dir': get_dir(lat,lng)
+			'dir': get_dir(lat,lng),
+			'addinfo': get_addinfo(pkmn.get('addinfo',0))
 		}
 		pkmn_info = self.optional_arguments(pkmn_info)
-			
+
+		#Check if the Pokemon will be back after a hidden phase
+		#Addinfo values: 1=2x15 point, 2=1x60h2 point, 3=1x60h3 point, 4=1x60h23 point, only needs to be added, if scanned before the break
+		addinfo = pkmn.get('addinfo',0)
+		reappear_texts = ('','\n15m later back for 15m.', '\n15m later back for 30m.', '\n30m later back for 15m.')
+		reappear_ind = (0, 1, 2, 1, 3)
+		pkmn_info['addinfo'] = reappear_texts[reappear_ind[addinfo]]
+
 		for alarm in self.alarms:
 			alarm.pokemon_alert(pkmn_info)
 
@@ -214,7 +222,7 @@ class Alarm_Manager(Thread):
 			if config['GEOFENCE'].contains(lat,lng) is not True:
 				log.info("Pokestop ignored: outside geofence")
 				return
-		
+
 		#Trigger the notifcations
 		log.info("Pokestop notication was triggered!")
 		timestamps = get_timestamps(dissapear_time)

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -279,11 +279,11 @@ def get_timestamps(t):
 	return (time_left, time_12, time_24)
 	
 # Check if the Pokemon will be back after a hidden phase
-# Addinfo values: 1=2x15 point, 2=1x60h2 point, 3=1x60h3 point, 4=1x60h23 point, only needs to be added, if scanned before the break
-def get_addinfo(addinfo):
-	reappear_texts = ('', '15m later back for 15m.', '15m later back for 30m.', '30m later back for 15m.')
-	reappear_ind = (0, 1, 2, 1, 3)
-	return reappear_texts[reappear_ind[addinfo]]
+# Spawn description values: 1=2x15 point, 2=1x60h2 point, 3=1x60h3 point, 4=1x60h23 point, only needs to be added, if scanned before the break
+def get_respawn_text(respawn_info):
+	respawn_texts = ('', '15m later back for 15m.', '15m later back for 30m.', '30m later back for 15m.')
+	respawn_inds = (0, 1, 2, 1, 3)
+	return respawn_texts[respawn_inds[respawn_info]]
 
 #########################################################################
 

--- a/alarms/utils.py
+++ b/alarms/utils.py
@@ -278,6 +278,13 @@ def get_timestamps(t):
 	time_24 = disappear_time.strftime("%H:%M:%S")
 	return (time_left, time_12, time_24)
 	
+# Check if the Pokemon will be back after a hidden phase
+# Addinfo values: 1=2x15 point, 2=1x60h2 point, 3=1x60h3 point, 4=1x60h23 point, only needs to be added, if scanned before the break
+def get_addinfo(addinfo):
+	reappear_texts = ('', '15m later back for 15m.', '15m later back for 30m.', '30m later back for 15m.')
+	reappear_ind = (0, 1, 2, 1, 3)
+	return reappear_texts[reappear_ind[addinfo]]
+
 #########################################################################
 
 ###################### PARAMS THAT REQUIRE API_KEY ######################


### PR DESCRIPTION
## Description
It'll enable third party tools to optionally include a new field named addinfo in the webhook request. That field brings support for all different spawn point types, 2x15,1x60h2,1x60h3 and 1x60h23.

An example: Say a 2x15 point is scanned right at the start, so without this pull request, you can either give an alarm for an expire time of 15 min, or 45 min. In reality the pokemon will stay for 15 min, hide for 15 min and then be back for 15 min, which would be a very useful information for the people receiving the alert, but it's not possible right now.

This pull request changes that.

## How Has This Been Tested?
Tested with PGO-mapscan-opt

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
If you integrate it, I can make a short wiki page.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. Only if you want to advertise this feature I guess ;)
- [ ] I have updated the documentation accordingly.

