### PR TITLE
Docker needs to run on all interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ EXPOSE 4000
 WORKDIR /usr/src/app
 
 # Set Entrypoint with hard-coded options
-ENTRYPOINT ["python", "./runwebhook.py"]
+ENTRYPOINT ["python", "./runwebhook.py", "--host", "0.0.0.0"]
 
 # Install required system packages
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
## Description

Fixed `--host` variable for Docker containers

A service in docker cannot run on 127.0.0.1 and expect to have network connectivity.

## How Has This Been Tested?

In Docker?

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update

No need to edit wiki, it's a bugfix.

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

