### PR TITLE
Preserve old_team on gym webhooks

### DIFF
--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -249,6 +249,13 @@ class Alarm_Manager(Thread):
 			log.debug("Gym ignored: no change detected")
 			return #ignore neutral for now
 		
+		# Preserve old_team so that there is no "Neutral" announcement
+		# Has the side effect of delaying the takedown until next scan.
+		if old_team == 0:
+			self.gyms[id] = old_team
+			log.debug("Gym ignored: migration to neutral, preserving old_team")
+			return
+		
 		#Check for Alert settings
 		old_team = get_team_name(old_team)
 		new_team = get_team_name(new_team)

--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -251,7 +251,7 @@ class Alarm_Manager(Thread):
 		
 		# Preserve old_team so that there is no "Neutral" announcement
 		# Has the side effect of delaying the takedown until next scan.
-		if old_team == 0:
+		if new_team == 0:
 			self.gyms[id] = old_team
 			log.debug("Gym ignored: migration to neutral, preserving old_team")
 			return


### PR DESCRIPTION
## Description

Preserve `old_team` when migrating to neutral so that there is only one announcement.  Next scan will properly announce:

    _old_team_ was defeated by _new_team_

Rather than two announcements:

    _old_team_ was defeated by Neutral
    Neutral was defeated by _new_team_

## How Has This Been Tested?

What's this word "tested"?

## Screenshots (if appropriate):

Not appropriate.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update

Gym announcements on defeats will take another scan.  This has pros and cons.  The good is that there will be enough time to get a good sense of who dropped in.  The bad is that you must wait another full rotation of your scanner to send the announcement.

This will be moot once prestige calculation is merged, because then you can see "_GYM_ is being attacked..." as the prestige lowers.

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Will update documentation upon acceptance of idea.