### PR TITLE
Added max_iv option

### DIFF
--- a/alarms/alarm_manager.py
+++ b/alarms/alarm_manager.py
@@ -28,7 +28,7 @@ class Alarm_Manager(Thread):
 			self.set_pokemon(settings["pokemon"])
 			log.info("The following pokemon are set:")
 			for id in sorted(self.pokemon_list.keys()):
-				log.info("{name}: max_dist({max_dist}), min_iv({min_iv}), move1({move_1}), move2({move_2})".format(**self.pokemon_list[id]))
+				log.info("{name}: max_dist({max_dist}), min_iv({min_iv}), max_iv({max_iv}), move1({move_1}), move2({move_2})".format(**self.pokemon_list[id]))
 			self.stop_list =  make_pokestops_list(settings["pokestops"])
 			self.gym_list = make_gym_list(settings["gyms"])
 			self.pokemon, self.pokestops, self.gyms = {}, {}, {}
@@ -75,8 +75,9 @@ class Alarm_Manager(Thread):
 	def set_pokemon(self, settings):
 		pokemon = {}
 		default_dist = float(settings.pop('max_dist', None) or 'inf');
-		default_iv = float(settings.pop('min_iv', None) or 0);
-		log.info("Pokemon Defaults: max_dist (%.2f) and min_iv (%.2f)" % (default_dist, default_iv))
+		default_min_iv = float(settings.pop('min_iv', None) or 0);
+		default_max_iv = float(settings.pop('max_iv', None) or 100);
+		log.info("Pokemon Defaults: max_dist (%.2f) and min_iv (%.2f) and max_iv (%.2f)" % (default_dist, default_min_iv, default_max_iv))
 		for name in settings:
 			id = get_pkmn_id(name)
 			if id is None:
@@ -93,7 +94,8 @@ class Alarm_Manager(Thread):
 					pokemon[id] = {
 						"name": get_pkmn_name(id),
 						"max_dist": float(info.get('max_dist', None) or default_dist),
-						"min_iv": float(info.get('min_iv', None) or default_iv),
+						"min_iv": float(info.get('min_iv', None) or default_min_iv),
+						"max_iv": float(info.get('max_iv', None) or default_max_iv),
 						"move_1": info.get("move_1", 'all'),
 						"move_2": info.get("move_2", 'all')
 					}
@@ -181,7 +183,10 @@ class Alarm_Manager(Thread):
 		if filter.get('min_iv') > float(iv):
 			log.info("%s ignored: IV was %f (needs to be %f)" % (name, iv, filter.get('min_iv')))
 			return
-		
+		elif filter.get('max_iv') < float(iv):
+			log.info("%s ignored: IV was %f (needs to be below %f)" % (name, iv, filter.get('max_iv')))
+			return
+            		
 		#Check moveset
 		move1 = get_pkmn_move(pkmn.get('move_1', "none"))
 		move2 = get_pkmn_move(pkmn.get('move_2', "none"))


### PR DESCRIPTION
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->


## Description
<!--- Describe your changes in detail -->
Added a max_iv parameter along with logging information
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Launched the two alarms, one with "min_iv":"0", and "max_iv":"50", and another alarm using @channel alerts with "min_iv":"50", and "max_iv":"100", . The results were @channel alerts on the latter with no double post.
<!--- Include details of your testing environment, and the tests you ran to -->
ran on macbook air OS X yosemite 10.10.5
<!--- see how your change affects other areas of the code, etc. -->
no other 


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) describing how to use your changes --->
set "max_iv":"desired value", for each pokemon being checked
<!--- Please keep them simple and user friendly                                  --->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.