### PR TITLE
Fix German translations of team names

### DIFF
--- a/locales/de/teams.json
+++ b/locales/de/teams.json
@@ -1,6 +1,6 @@
 {
   "0":"Neutral",
-  "1":"Mystiker",
-  "2":"Tapferkeit",
-  "3":"Instinkt"
+  "1":"Weisheit",
+  "2":"Wagemut",
+  "3":"Intuition"
 }


### PR DESCRIPTION

## Description
The German translations of the team names are wrong. They look like they've been translated via google translator. I replaced them with the correct names.

## How Has This Been Tested?
not needed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) describing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->
not needed

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.