### PR TITLE
Split tweets into two if they exceed Twitter limit of 140 characters

### DIFF
--- a/PokeAlarm/Twitter/TwitterAlarm.py
+++ b/PokeAlarm/Twitter/TwitterAlarm.py
@@ -88,6 +88,7 @@ class  TwitterAlarm(Alarm):
         else:                                                       # No gmaps link found
             maps_link_included = False
             max_length = MAX_TWEET_LEN
+            alert_str = alert['status']
             
         if len(alert_str) > max_length:
             alert_str2 = "[1/2] " + alert_str[0:(max_length-6)]     # subtract 6 due to the '[1/2] ' string length

--- a/PokeAlarm/Twitter/TwitterAlarm.py
+++ b/PokeAlarm/Twitter/TwitterAlarm.py
@@ -7,6 +7,8 @@ from twitter import Twitter, OAuth
 from ..Alarm import Alarm
 from ..Utils import parse_boolean, get_time_as_str
 
+MAX_TWEET_LEN = 140
+
 log = logging.getLogger(__name__)
 try_sending = Alarm.try_sending
 replace = Alarm.replace
@@ -70,7 +72,7 @@ class  TwitterAlarm(Alarm):
 
     # Post Pokemon Status
     def send_alert(self, alert, info):
-        args = {"status": replace(alert['status'], info)}
+        args = {"status": replace(alert['status'], info)[:MAX_TWEET_LEN]}
         try_sending(log, self.connect, "Twitter", self.__client.statuses.update, args)
 
     # Trigger an alert based on Pokemon info

--- a/PokeAlarm/Twitter/TwitterAlarm.py
+++ b/PokeAlarm/Twitter/TwitterAlarm.py
@@ -88,7 +88,7 @@ class  TwitterAlarm(Alarm):
         else:                                                       # No gmaps link found
             maps_link_included = False
             max_length = MAX_TWEET_LEN
-            alert_str = alert['status']
+            alert_str = replace(alert['status'], info)
             
         if len(alert_str) > max_length:
             alert_str2 = "[1/2] " + alert_str[0:(max_length-6)]     # subtract 6 due to the '[1/2] ' string length


### PR DESCRIPTION
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->
<!--- PULL REQUESTS CREATED NOT USING THE BELOW TEMPLATE WILL BE CLOSED WITHOUT RESPONSE --->


## Description
<!--- Describe your changes in detail -->
Twitter currently allows tweets to be a maximum of 140 characters. There is no error checking in PokeAlarm at this time. After text substitutions, some tweets may be too long and this is not easily noticed unless logs are monitored.  I know multiple very knowledgeable people who just recently discovered missing tweets due to this issue.  This PR avoids missing tweets.

Twitter treats URLs of any size as 23 characters against the 140 limit.  So the \<gmaps\> tag translates to 23 characters and there needs to be a space in front of the URL so effectively it is 24 characters.  This leaves 116 characters for the rest of the tweet.

This code checks to see if a tweet > 140 characters with no \<gmaps\> substitution in the status string or > 116 characters if there is a \<gmaps\> substitution.  If above the appropriate limit, it will split the tweet into two and append [1/2] and [2/2] to the front of these tweets.  And because it looks better in the stream, the code puts the \<gmaps\> tag on both tweets if there was a \<gmaps\> substitution requested.

It splits the tweet by simply splitting the status string into two at the appropriate limit (140 or 116).  If the \<gmaps\> substitution was requested, that is appended to the end of the string also.  The split is not elegant but this situation should be considered an error condition since currently the tweets are simply erroring out and being lost.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created an alerts file with 5 twitter alarms each with a status string of 200 characters and a different method of specifying \<gmaps\> to ensure all cases were covered
1.  '\<gmaps\> ' was at start of string
2.  ' \<gmaps\>' was at end of string
3.  ' \<gmaps\> ' was inside string
4.  '\<gmaps\>' was inside string (invalid status string since URL needs spaces around it)
5.  String with '\<gmaps\>' along with text substitutions

In all cases, the string was split in exactly the correct location, two tweets were generated, and the map was applied to each

I also checked strings without a \<gmaps\> substitution:
1.  200 string character with no substitutions

In all cases, the string was split in exactly the correct location, two tweets were generated, no maps were appended.

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/15407947/23328591/c1de3c50-faea-11e6-88d4-48afeee590cc.png)

![image](https://cloud.githubusercontent.com/assets/15407947/23328883/ef6f490a-faf1-11e6-9741-5b8f60167f55.png)

![image](https://cloud.githubusercontent.com/assets/15407947/23329097/3fd31648-faf6-11e6-8ae9-645bb0659bdc.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) describing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->
Not needed

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.