### PR TITLE
Added the ability to have an apple maps formated url that will

### DIFF
--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -236,6 +236,10 @@ def get_gmaps_link(lat, lng):
     latlng = '{},{}'.format(repr(lat), repr(lng))
     return 'http://maps.google.com/maps?q={}'.format(latlng)
 
+#Returns a String link to Apple Maps Pin at the location	
+def get_applemaps_link(lat, lng):
+	latLon = '{},{}'.format(repr(lat), repr(lng))
+	return 'http://maps.apple.com/maps?daddr={}&z=10&t=s&dirflg=w'.format(latLon)
 
 # Returns a static map url with <lat> and <lng> parameters for dynamic test
 def get_static_map_url(settings, api_key=None):  # TODO: optimize formatting

--- a/PokeAlarm/WebhookStructs.py
+++ b/PokeAlarm/WebhookStructs.py
@@ -5,7 +5,7 @@ import traceback
 # 3rd Party Imports
 # Local Imports
 from Utils import get_gmaps_link, get_move_damage, get_move_dps, get_move_duration,\
-    get_move_energy, get_pokemon_gender, get_pokemon_size
+    get_move_energy, get_pokemon_gender, get_pokemon_size, get_applemaps_link
 
 log = logging.getLogger('WebhookStructs')
 
@@ -70,7 +70,8 @@ class RocketMap:
             'weight': check_for_none(float, data.get('weight'), 'unkn'),
             'gender': get_pokemon_gender(check_for_none(int, data.get('gender'), '?')),
             'size': 'unknown',
-            'gmaps': get_gmaps_link(lat, lng)
+            'gmaps': get_gmaps_link(lat, lng),
+            'applemaps': get_applemaps_link(lat, lng)
         }
         if pkmn['atk'] != '?' or pkmn['def'] != '?' or pkmn['sta'] != '?':
             pkmn['iv'] = float(((pkmn['atk'] + pkmn['def'] + pkmn['sta']) * 100) / float(45))


### PR DESCRIPTION

## Description
open/create a pin in apple maps.  This allows you to use your apple watch easily to
navigate to the pokemon while still keeping open the Pokemon Go App.

There now exists <applemaps> (i.e. just like <gmaps>) to allow for text
replacement.

## How Has This Been Tested?
I use it daily.  And the twitter I have set up uses it also

## Screenshots (if appropriate):

## Types of changes

- [X ] New feature (non-breaking change which adds functionality)

## Wiki Update
<!--- Please create a Wiki page (or snippet) describing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->

On this page  https://github.com/kvangent/PokeAlarm/wiki/Dynamic-Text-Substitution

add: 

<applemaps>	Apple Maps URL to pokemon location


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.