### PR TITLE
Reusable Filters

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -13,7 +13,7 @@ import gipc
 import googlemaps
 # Local Imports
 from . import config
-from Filters import Geofence, load_pokemon_section, load_pokestop_section, load_gym_section
+from Filters import Geofence, load_pokemon_section, load_pokestop_section, load_gym_section, load_filters
 from Utils import get_cardinal_dir, get_dist_as_str, get_earth_dist, get_path, get_time_as_str, \
     require_and_remove_key, parse_boolean, contains_arg
 log = logging.getLogger('Manager')
@@ -84,6 +84,9 @@ class Manager(object):
             log.info("Loading Filters from file at {}".format(file_path))
             with open(file_path, 'r') as f:
                 filters = json.load(f)
+
+            # Load in the filter definitions
+            load_filters(filters)
 
             # Load in the Pokemon Section
             self.__pokemon_settings = load_pokemon_section(

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -288,6 +288,8 @@ def get_cardinal_dir(pt_a, pt_b=None):
 def get_dist_as_str(dist):
     if dist == 'unkn':
         return 'unkn'
+    if dist == float("inf"):
+        return "infinite"
     if config['UNITS'] == 'imperial':
         if dist > 1760:  # yards per mile
             return "{:.1f}mi".format(dist / 1760.0)

--- a/filters.json.example
+++ b/filters.json.example
@@ -1,8 +1,59 @@
 {
+    "filters": {
+        "No Crap": {
+            "min_iv": "60"
+        },
+        "Low IV": {
+            "min_iv": "0",
+            "max_iv": "60"
+        },
+        "Perfects": {
+            "min_iv": "100"
+        },
+        "Nineties": {
+            "max_dist": "2000",
+            "min_iv": "90"
+        },
+        "Nearby": {
+            "max_dist": "50"
+        },
+        "Right Here": {
+            "max_dist": "10"
+        },
+        "Far Away And Bad": {
+            "min_dist": "3000",
+            "min_iv": "0",
+            "max_iv": "40"
+        },
+        "Bubblers": {
+            "quick_move": ["Bubble"]
+        },
+        "Valorified": {
+            "to_team": ["Valor"]
+        }
+    },
+    "filter_sets": {
+        "Standard": [
+            "Perfects",
+            "Nineties",
+            "Nearby"
+        ],
+        "Candy": [
+            "Nearby",
+            "Low IV"
+        ],
+        "Bubble Boy": [
+            "Bubblers",
+            {
+                "charge_move": ["Bubble Beam"]
+            }
+        ]
+    },
     "gyms":{
         "enabled":"False",
-        "ignore_neutral":"False",
-        "filters":[
+        "ignore_neutral":"True",
+        "filters": [
+            "Valorified",
             {
                 "from_team":["Valor", "Instinct", "Mystic"], "to_team":["Valor", "Instinct", "Mystic"],
                 "min_dist":"0", "max_dist":"inf"
@@ -11,39 +62,21 @@
     },
     "pokestops":{
         "enabled":"False",
-        "filters":{ "min_dist":"0", "max_dist":"10" }
+        "filters":"Right Here"
     },
     "pokemon":{
-        "enabled":"False",
-        "default": {
-            "min_dist":"0", "max_dist":"inf",
-            "min_iv":"0", "max_iv":"100", "min_atk": "0", "max_atk":"15",
-            "min_def": "0", "max_def":"15", "min_sta": "0", "max_sta":"15",
-            "quick_move": null, "charge_move": null, "moveset": null,
-            "size": null, "ignore_missing": "False"
-        },
-        "Bulbasaur":[
-            {
-                "min_dist":"0", "max_dist":"inf", "min_iv":"0", "max_iv":"100",
-                "min_atk": "0", "max_atk":"0", "min_def": "0", "max_def":"15", "min_sta": "0", "max_sta":"15",
-                "quick_move": null, "charge_move": null, "moveset": null, "size": null, "ignore_missing": "False"
-            },
-           {
-                "min_dist":"0", "max_dist":"inf", "min_iv":"0", "max_iv":"100",
-                "min_atk": "0", "max_atk":"15", "min_def": "0", "max_def":"15", "min_sta": "0", "max_sta":"15",
-                "quick_move": ["Vine Whip"], "charge_move": ["Sludge Bomb"], "moveset": ["Vine Whip/Sludge Bomb"],
-                "size": null, "ignore_missing": "False"
-           }
-        ],
-        "Ivysaur":{ "min_iv":"0", "max_iv":"100" },
-        "Venusaur": "False",
+        "enabled":"True",
+        "default":"No Crap",
+        "Bulbasaur":{ "min_dist":"0", "max_dist":"inf" },
+        "Ivysaur":"Far Away And Bad",
+        "Venusaur":{ "quick_move":[ "Razor Leaf", "Vine Whip" ], "charge_move":[ "Petal Blizzard", "Sludge Bomb", "Solar Beam" ]},
         "Charmander":{ "moveset":[ "Ember/Flame Burst", "Scratch/Flame Charge" ] },
-        "Charmeleon":{ "min_iv":"100" , "ignore_missing":"False" },
-        "Charizard":"False",
-        "Squirtle":"False",
-        "Wartortle":"False",
-        "Blastoise":"False",
-        "Caterpie":"False",
+        "Charmeleon":{ "min_iv":"100" , "ignore_missing":"True" },
+        "Charizard":"Nineties",
+        "Squirtle":"Bubble Boy",
+        "Wartortle":"True",
+        "Blastoise":"Standard",
+        "Caterpie":"Candy",
         "Metapod":"False",
         "Butterfree":"False",
         "Weedle":"False",
@@ -281,7 +314,7 @@
         "Suicune":"False",
         "Larvitar":"False",
         "Pupitar":"False",
-        "Tyranitar":"False",
+        "Tyranitar": "False",
         "Lugia":"False",
         "Ho-Oh":"False",
         "Celebi":"False"


### PR DESCRIPTION
## Description
Now that PokeAlarm support multiple filters the filters.json file might get a little bit crowded. Also you will usually use the same filter(s) for many different Pokemon, so if you like to modify these filter(s) you have to change them at many different places.

First of all I'd like to give things names:

**Filter** - This is usually a dictionary (or map) written with curly braces "{ ... }". All Conditions in one filter have to be true for the filter to match. This is what PokeAlarm had from the beginning. Example:
```
{"max_dist": "5000", "min_iv": "95"}
```

**Filter Set** - This is a list of multiple filters. A filter set matches if at least one of the filters of the set matches. This is the new thing for PokeAlarm 3.1 (yay!). Example:
```
[
    {"max_dist": "5000", "min_iv": "95"},
    {"max_dist": "200"}
]
```

With this PR you can give filters and filter sets names:
```
"filters": {
    "No Crap": { "min_iv": 60 },
    "Perfect": { "min_iv": 100 },
    "Nineties": { "max_dist": 5000, "min_iv": 95 },
    "Gym Gone Red": { "to_team": ["Valor"] },
    "Red Gym Lost": { "from_team": ["Valor"] },
    "Right Here": { "max_dist": "10" }
},
"filter_sets": {
    "Standard": [
        "Perfect",
        "Nineties"
    ],
    "Bubble Boy": [
        { "quick_move": ["Bubble"] },
        { "charge_move": ["Bubble Beam"] }
    ]
}
```
You can now use these names wherever a filter definition is allowed. Above you already saw that you can reference a filter by its name in a filter set. You can also...

...reference a filter or filter set by its name in a Pokemon (even the "default" one) filter configuration:
```
"pokemon":{
    "default":"No Crap",
    "Bulbasaur": "Standard",
    "Ivysaur": "Nineties",
    "Venusaur": "Bubble Boy"
}
```

...reference a filter in Gym configuration:
```
"gyms":{
    "enabled":"True",
    "ignore_neutral":"True",
    "filters": [
        "Gym Gone Red",
        "Red Gym Lost"
    ]
}
```

...and even use it in Pokestop configuration:
```
"pokestops":{
    "enabled":"False",
    "filters":"Right Here"
}
```

All this is **fully backwards compatible**. You don't need to define filters or filter sets with names, you can still use everything as before, writing down in its full length every single filter you need. And of course you can mix the traditional style with this "new" style.

In  my opinion this leads to a much cleaner filter.json file with the benefit of having your actual filter definitions centralized so if you want to modify them you do it at **one** place only.

Note that I also came across the idea of moving the filter definitions to a separate file that is being shared by all managers. For me this sounds like a good idea although I personally only use one manager. This hasn't been done yet.

## How Has This Been Tested?
My small VPS running RocketMap + PA3.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
Coming soon... (if there is positive feedback)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.