### PR TITLE
Add filter by gender

### DIFF
--- a/PokeAlarm/Filters.py
+++ b/PokeAlarm/Filters.py
@@ -46,7 +46,8 @@ def load_pokemon_section(settings):
         "min_def": 0, "max_def": 15,
         "min_sta": 0, "max_sta": 15,
         "quick_move": None, "charge_move": None, "moveset": None,
-        "size": None
+        "size": None,
+        "gender": None
     }, 'default')
     default = default_filt.to_dict()
     # Add the filters to the settings
@@ -152,6 +153,7 @@ class PokemonFilter(Filter):
         self.max_sta = int(settings.pop('max_sta', None) or default['max_sta'])
         # Size
         self.sizes = PokemonFilter.check_sizes(settings.pop("size", default['size']))
+        self.genders = PokemonFilter.check_genders(settings.pop("gender", default['gender']))
         # Moves - These can't be set in the default filter
         self.req_quick_move = PokemonFilter.create_moves_list(settings.pop("quick_move", default['quick_move']))
         self.req_charge_move = PokemonFilter.create_moves_list(settings.pop("charge_move", default['charge_move']))
@@ -206,6 +208,12 @@ class PokemonFilter(Filter):
             return True
         return size in self.sizes
 
+    # Checks the gender against this filter
+    def check_gender(self, gender):
+        if self.genders is None:
+            return True
+        return gender in self.genders
+
     # Convert this filter to a dict
     def to_dict(self):
         return {
@@ -217,6 +225,7 @@ class PokemonFilter(Filter):
             "quick_move": self.req_quick_move, "charge_move": self.req_charge_move,
             "moveset": self.req_moveset,
             "size": self.sizes,
+            "gender": self.genders,
             "ignore_missing": self.ignore_missing
         }
 
@@ -231,6 +240,7 @@ class PokemonFilter(Filter):
                "Charge Moves: {}, ".format(self.req_charge_move) + \
                "Move Sets: {}, ".format(self.req_moveset)  +\
                "Sizes: {}, ".format(self.sizes) + \
+               "Genders: {}, ".format(self.genders) + \
                "Ignore Missing: {} ".format(self.ignore_missing)
 
     @staticmethod
@@ -274,6 +284,36 @@ class PokemonFilter(Filter):
             else:
                 log.error("{} is not a valid size name.".format(size))
                 log.error("Please use one of the following: {}".format(valid_sizes))
+                sys.exit(1)
+        return list_
+
+
+    @staticmethod
+    def check_genders(genders):
+        if genders is None:  # no genders
+            return None
+        list_ = set()
+        valid_genders = ['male', 'female', 'neutral']
+        for raw_gender in genders:
+            log.debug("raw_gender: {}".format(raw_gender))
+            gender = raw_gender
+            if raw_gender == u'\u2642':
+              gender = 'male'
+            if raw_gender == u'\u2640':
+              gender = 'female'
+            if raw_gender == u'\u26b2':
+              gender = 'neutral'
+            log.debug("gender: {}".format(gender))
+            if gender in valid_genders:
+                if gender == 'male':
+                  list_.add(u'\u2642')
+                if gender == 'female':
+                  list_.add(u'\u2640')
+                if gender == 'neutral':
+                  list_.add(u'\u26b2')
+            else:
+                log.error("{} is not a valid gender name.".format(gender))
+                log.error("Please use one of the following: {}".format(valid_genders))
                 sys.exit(1)
         return list_
 

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -339,6 +339,7 @@ class Manager(object):
         quick_id = pkmn['quick_id']
         charge_id = pkmn['charge_id']
         size = pkmn['size']
+        gender = pkmn['gender']
 
         filters = self.__pokemon_settings['filters'][pkmn_id]
         for filt_ct in range(len(filters)):
@@ -453,6 +454,18 @@ class Manager(object):
                     log.info("{} rejected: Size information was missing - (F #{})".format(name, filt_ct))
                     continue
                 log.debug("Pokemon 'size' was not checked because it was missing.")
+
+            # Check for a valid gender
+            if gender != 'unknown':
+                if not filt.check_gender(gender):
+                    if self.__quiet is False:
+                        log.info("{} rejected: Gender ({}) was not correct - (F #{})".format(name, gender, filt_ct))
+                    continue
+            else:
+                if filt.ignore_missing is True:
+                    log.info("{} rejected: Gender information was missing - (F #{})".format(name, filt_ct))
+                    continue
+                log.debug("Pokemon 'gender' was not checked because it was missing.")
 
             # Nothing left to check, so it must have passed
             passed = True

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -215,7 +215,7 @@ def get_pokemon_size(pokemon_id, height, weight):
         return 'big'
 
 
-# Returns the (appraisal) size of a pokemon:
+# Returns the gender symbol of a pokemon:
 def get_pokemon_gender(gender):
     if gender == 1:
         return u'\u2642'  # male symbol

--- a/filters.json.example
+++ b/filters.json.example
@@ -20,7 +20,7 @@
             "min_iv":"0", "max_iv":"100", "min_atk": "0", "max_atk":"15",
             "min_def": "0", "max_def":"15", "min_sta": "0", "max_sta":"15",
             "quick_move": null, "charge_move": null, "moveset": null,
-            "size": null, "ignore_missing": "False"
+            "size": null, "gender": null, "ignore_missing": "False"
         },
         "Bulbasaur":[
             {


### PR DESCRIPTION
## Description
Adds the ability to filter on pokemon gender. See issue #356

Syntax example:
"Charmeleon":{ "min_iv":"100" , "gender":["male","female","neutral"] },

## How Has This Been Tested?
Run for 24 hours on my server, posting alerts filtered on IV plus male/female to Discord channels.
 
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
<!--- Please create a Wiki page (or snippet) describing how to use your changes --->
<!--- Please keep them simple and user friendly                                  --->
See: https://github.com/kvangent/PokeAlarmWiki/pull/46

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
