### PR TITLE
add color to discord embeds

### DIFF
--- a/PokeAlarm/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Discord/DiscordAlarm.py
@@ -4,7 +4,7 @@ import requests
 # 3rd Party Imports
 # Local Imports
 from ..Alarm import Alarm
-from ..Utils import parse_boolean, get_static_map_url, reject_leftover_parameters, require_and_remove_key
+from ..Utils import parse_boolean, get_static_map_url, reject_leftover_parameters, require_and_remove_key, get_color
 
 log = logging.getLogger('Discord')
 try_sending = Alarm.try_sending
@@ -27,7 +27,8 @@ class DiscordAlarm(Alarm):
             'avatar_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/<pkmn_id>.png",
             'title': "A wild <pkmn> has appeared!",
             'url': "<gmaps>",
-            'body': "Available until <24h_time> (<time_left>)."
+            'body': "Available until <24h_time> (<time_left>).",
+            'color': "<iv_0>"
         },
         'pokestop': {
             'username': "Pokestop",
@@ -36,7 +37,8 @@ class DiscordAlarm(Alarm):
             'avatar_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/pokestop.png",
             'title': "Someone has placed a lure on a Pokestop!",
             'url': "<gmaps>",
-            'body': "Lure will expire at <24h_time> (<time_left>)."
+            'body': "Lure will expire at <24h_time> (<time_left>).",
+            'color': "<time_left>"
         },
         'gym': {
             'username': "<new_team> Gym Alerts",
@@ -45,7 +47,8 @@ class DiscordAlarm(Alarm):
             'avatar_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_<team_id>.png",
             'title': "A Team <old_team> gym has fallen!",
             'url': "<gmaps>",
-            'body': "It is now controlled by <new_team>."
+            'body': "It is now controlled by <new_team>.",
+            'color': "<new_team>"
         }
     }
 
@@ -101,6 +104,7 @@ class DiscordAlarm(Alarm):
             'title': settings.pop('title', default['title']),
             'url': settings.pop('url', default['url']),
             'body': settings.pop('body', default['body']),
+            'color': default['color'],
             'map': get_static_map_url(settings.pop('map', self.__map), self.__static_map_key)
         }
 
@@ -120,6 +124,7 @@ class DiscordAlarm(Alarm):
                 'title': replace(alert['title'], info),
                 'url': replace(alert['url'], info),
                 'description': replace(alert['body'], info),
+                'color': get_color(replace(alert['color'], info)),
                 'thumbnail': {'url': replace(alert['icon_url'], info)}
             }]
             if alert['map'] is not None:

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -226,6 +226,40 @@ def get_pokemon_gender(gender):
     return '?' # catch all
 
 
+# Returns color for discord embeds
+def get_color(color_id):
+    try:
+        if int(color_id) < 25:
+            color_ = 0x9d9d9d
+        elif int(color_id) < 50:
+            color_ = 0xffffff
+        elif int(color_id) < 81:
+            color_ = 0x1eff00
+        elif int(color_id) < 90:
+            color_ = 0x0070dd
+        elif int(color_id) < 100:
+            color_ = 0xa335ee
+        elif int(color_id) == 100:
+            color_ = 0xff8000
+    except:
+        try:
+            if color_id == "?":
+                color_ = 0x4F545C
+            elif color_id == "Valor":
+                color_ = 0xFE0103
+            elif color_id == "Mystic":
+                color_ = 0x1102FD
+            elif color_id == "Instinct":
+                color_ = 0xF6F006
+            elif color_id[-1] == 's':
+                color_ = 0xff66ff
+            else:
+                color_ = 0x4F545C
+        except:
+            color_ = 0x4F545C
+    return color_
+
+
 ########################################################################################################################
 
 ################################################# GMAPS API UTILITIES ##################################################


### PR DESCRIPTION
## Description
Adds color to discord embeds based on IV (in the case of pokemon), team (in the case of gym), or simply if it is a lured pokestop.  Examples in screenshot

## How Has This Been Tested?
I've been using this set up for months without flaw

## Screenshots (if appropriate):
[Screenshot of pokemon example](http://imgur.com/cvcvWjw)
[Screenshot of gym example](http://imgur.com/sN62LWR)
[Screenshot of lure example](http://imgur.com/XWPkT22)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.