### PR TITLE
Size tweak

### DIFF
--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -207,6 +207,8 @@ def get_pokemon_size(pokemon_id, height, weight):
         return 'tiny'
     elif size > 2.5 and pokemon_id == 129:
         return 'big'
+    else:
+	return ''
 
 
 # Returns the gender symbol of a pokemon:

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -203,9 +203,9 @@ def size_ratio(pokemon_id, height, weight):
 # Returns the (appraisal) size of a pokemon:
 def get_pokemon_size(pokemon_id, height, weight):
     size = size_ratio(pokemon_id, height, weight)
-    if size < 1.5 and pokemon_id = 19:
+    if size < 1.5 and pokemon_id == 19:
         return 'tiny'
-    elif size > 2.5 and pokemon_id = 129:
+    elif size > 2.5 and pokemon_id == 129:
         return 'big'
 
 

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -203,15 +203,9 @@ def size_ratio(pokemon_id, height, weight):
 # Returns the (appraisal) size of a pokemon:
 def get_pokemon_size(pokemon_id, height, weight):
     size = size_ratio(pokemon_id, height, weight)
-    if size < 1.5:
+    if size < 1.5 and pokemon_id = 19:
         return 'tiny'
-    elif size <= 1.75:
-        return 'small'
-    elif size < 2.25:
-        return 'normal'
-    elif size <= 2.5:
-        return 'large'
-    else:
+    elif size > 2.5 and pokemon_id = 129:
         return 'big'
 
 

--- a/PokeAlarm/WebhookStructs.py
+++ b/PokeAlarm/WebhookStructs.py
@@ -70,7 +70,7 @@ class RocketMap:
             'height': check_for_none(float, data.get('height'), 'unkn'),
             'weight': check_for_none(float, data.get('weight'), 'unkn'),
             'gender': get_pokemon_gender(check_for_none(int, data.get('gender'), '?')),
-            'size': 'unknown',
+            'size': '',
             'gmaps': get_gmaps_link(lat, lng),
             'applemaps': get_applemaps_link(lat, lng)
         }
@@ -79,7 +79,7 @@ class RocketMap:
         else:
             pkmn['atk'], pkmn['def'], pkmn['sta'] = '?', '?', '?'
 
-        if pkmn['height'] != 'unkn' or pkmn['weight'] != 'unkn':
+        if (pkmn['height'] != 'unkn' or pkmn['weight'] != 'unkn') and (pkmn['pkmn_id'] == 19 or pkmn['pkmn_id'] == 129):
             pkmn['size'] = get_pokemon_size(pkmn['pkmn_id'], pkmn['height'], pkmn['weight'])
             pkmn['height'] = "{:.2f}".format(pkmn['height'])
             pkmn['weight'] = "{:.2f}".format(pkmn['weight'])


### PR DESCRIPTION
## Description
This makes it so it only big karps or tiny rats get size reported.  If it is anything but a big karp or a tiny rat, it returns an empty string ''.  This makes it so you don't need a separate manager to report size.

## How Has This Been Tested?
I've tested on my setup and works well

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.