### PR TITLE
V3.2 lure time fix

### DIFF
--- a/PokeAlarm/Filters.py
+++ b/PokeAlarm/Filters.py
@@ -42,6 +42,7 @@ def load_pokemon_section(settings):
         "ignore_missing": False,
         "min_dist": 0.0, "max_dist": float('inf'),
         "min_cp": 0, "max_cp": 4760,
+        "min_level": 0, "max_level": 40,
         "min_iv": 0.0, "max_iv": 100.0,
         "min_atk": 0, "max_atk": 15,
         "min_def": 0, "max_def": 15,
@@ -146,6 +147,9 @@ class PokemonFilter(Filter):
         # CP
         self.min_cp = int(settings.pop('min_cp', None) or default['min_cp'])
         self.max_cp = int(settings.pop('max_cp', None) or default['max_cp'])
+        # Level
+        self.min_level = int(settings.pop('min_level', None) or default['min_level'])
+        self.max_level = int(settings.pop('max_level', None) or default['max_level'])
         # IVs
         self.min_iv = float(settings.pop('min_iv', None) or default['min_iv'])
         self.max_iv = float(settings.pop('max_iv', None) or default['max_iv'])
@@ -172,6 +176,10 @@ class PokemonFilter(Filter):
     # Checks the CP against this filter
     def check_cp(self, cp):
         return self.min_cp <= cp <= self.max_cp
+
+    # Checks the Level against this filter
+    def check_level(self, level):
+        return self.min_level <= level <= self.max_level
 
     # Checks the IV percent against this filter
     def check_iv(self, dist):
@@ -227,6 +235,7 @@ class PokemonFilter(Filter):
         return {
             "min_dist": self.min_dist, "max_dist": self.max_dist,
             "min_cp": self.min_cp, "max_cp": self.max_cp,
+            "min_level": self.min_level, "max_level": self.max_level,
             "min_iv": self.min_iv, "max_iv": self.max_iv,
             "min_atk": self.min_atk, "max_atk": self.max_atk,
             "min_def": self.min_def, "max_def": self.max_def,
@@ -242,6 +251,7 @@ class PokemonFilter(Filter):
     def to_string(self):
         return "Dist: {} to {}, ".format(self.min_dist, self.max_dist) + \
                "CP: {} to {}, ".format(self.min_cp, self.max_cp) + \
+               "Level: {} to {}, ".format(self.min_level, self.max_level) + \
                "IV%: {} to {}, ".format(self.min_iv, self.max_iv) +  \
                "Atk: {} to {}, ".format(self.min_atk, self.max_atk) + \
                "Def: {} to {}, ".format(self.min_def, self.max_def) + \

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -333,6 +333,7 @@ class Manager(object):
         lat, lng = pkmn['lat'], pkmn['lng']
         dist = get_earth_dist([lat, lng], self.__latlng)
         cp = pkmn['cp']
+        level = pkmn['level']
         iv = pkmn['iv']
         def_ = pkmn['def']
         atk = pkmn['atk']
@@ -368,6 +369,20 @@ class Manager(object):
                     log.info("{} rejected: CP information was missing - (F #{})".format(name, filt_ct))
                     continue
                 log.debug("Pokemon 'cp' was not checked because it was missing.")
+
+
+            # Check the Level of the Pokemon
+            if level != '?':
+                if not filt.check_level(level):
+                    if self.__quiet is False:
+                        log.info("{} rejected: Level ({}) not in range {} to {} - (F #{})".format(
+                            name, level, filt.min_level, filt.max_level, filt_ct))
+                    continue
+            else:
+                if filt.ignore_missing is True:
+                    log.info("{} rejected: Level information was missing - (F #{})".format(name, filt_ct))
+                    continue
+                log.debug("Pokemon 'level' was not checked because it was missing.")
 
             # Check the IV percent of the Pokemon
             if iv != '?':

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -333,7 +333,10 @@ def get_time_as_str(t, timezone=None):
     else:
         disappear_time = datetime.now() + d
     # Time remaining in minutes and seconds
-    time_left = "%dm %ds" % (m, s)
+    if h == 0:
+        time_left = "%dm %ds" % (m, s)
+    else:
+        time_left = "%dh %dm" % (h, m)
     # Dissapear time in 12h format, eg "2:30:16 PM"
     time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower()
     # Dissapear time in 24h format including seconds, eg "14:30:16"

--- a/PokeAlarm/WebhookStructs.py
+++ b/PokeAlarm/WebhookStructs.py
@@ -53,6 +53,7 @@ class RocketMap:
             'lat': float(data['latitude']),
             'lng': float(data['longitude']),
             'cp': check_for_none(int, data.get('cp'), '?'),
+            'level': check_for_none(int, data.get('pokemon_level'), '?'),
             'iv': '?',
             'atk': check_for_none(int, data.get('individual_attack'), '?'),
             'def': check_for_none(int, data.get('individual_defense'), '?'),


### PR DESCRIPTION
## Description
With the current event lures last for 6 hours and RM has a lure_duration config command to extend the time.  However, PA reports the time as 59m 59s.  This fixes so that if time_left is over an hour it reports xh ym so that lure times can be accurate

## How Has This Been Tested?
Yes

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.