### PR TITLE
lure time bugfix

### DIFF
--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -333,10 +333,7 @@ def get_time_as_str(t, timezone=None):
     else:
         disappear_time = datetime.now() + d
     # Time remaining in minutes and seconds
-    if h == 0:
-        time_left = "%dm %ds" % (m, s)
-    else:
-        time_left = "%dh %dm" % (h, m)
+    time_left = "%dm %ds" % (m, s) if h != 0 else "%dh %dm" % (h, m)
     # Dissapear time in 12h format, eg "2:30:16 PM"
     time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower()
     # Dissapear time in 24h format including seconds, eg "14:30:16"

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -333,7 +333,10 @@ def get_time_as_str(t, timezone=None):
     else:
         disappear_time = datetime.now() + d
     # Time remaining in minutes and seconds
-    time_left = "%dm %ds" % (m, s)
+    if h == 0:
+        time_left = "%dm %ds" % (m, s)
+    else:
+        time_left = "%dh %dm" % (h, m)
     # Dissapear time in 12h format, eg "2:30:16 PM"
     time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower()
     # Dissapear time in 24h format including seconds, eg "14:30:16"

--- a/PokeAlarm/Utils.py
+++ b/PokeAlarm/Utils.py
@@ -333,7 +333,7 @@ def get_time_as_str(t, timezone=None):
     else:
         disappear_time = datetime.now() + d
     # Time remaining in minutes and seconds
-    time_left = "%dm %ds" % (m, s) if h != 0 else "%dh %dm" % (h, m)
+    time_left = "%dm %ds" % (m, s) if h == 0 else "%dh %dm" % (h, m)
     # Dissapear time in 12h format, eg "2:30:16 PM"
     time_12 = disappear_time.strftime("%I:%M:%S") + disappear_time.strftime("%p").lower()
     # Dissapear time in 24h format including seconds, eg "14:30:16"


### PR DESCRIPTION
## Description
With the current event lures last for 6 hours and RM has a lure_duration config command to extend the time.  However, PA reports the time as 59m 59s.  This fixes so that if time_left is over an hour it reports xh ym so that lure times can be accurate

## How Has This Been Tested?
Yes

## Screenshots (if appropriate):
Old:
![screenshot 2017-05-06 at 11 51 41 am](https://cloud.githubusercontent.com/assets/25806770/25773819/8e80aa56-3252-11e7-92b3-e5beadcaf3c1.png)

New:
![screenshot 2017-05-06 at 11 51 49 am](https://cloud.githubusercontent.com/assets/25806770/25773820/98e233ac-3252-11e7-86fc-def671d3aa61.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.