### PR TITLE
Update URI of raid icons to point to master

### DIFF
--- a/PokeAlarm/Discord/DiscordAlarm.py
+++ b/PokeAlarm/Discord/DiscordAlarm.py
@@ -50,8 +50,8 @@ class DiscordAlarm(Alarm):
         'egg': {
             'username': "Egg",
             'content': "",
-            'icon_url': "https://raw.githubusercontent.com/fosJoddie/PokeAlarm/raids/icons/egg_<raid_level>.png",
-            'avatar_url': "https://raw.githubusercontent.com/fosJoddie/PokeAlarm/raids/icons/egg_<raid_level>.png",
+            'icon_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/egg_<raid_level>.png",
+            'avatar_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/egg_<raid_level>.png",
             'title': "Raid is incoming!",
             'url': "<gmaps>",
             'body': "A level <raid_level> raid will hatch <begin_24h_time> (<begin_time_left>)."
@@ -60,7 +60,7 @@ class DiscordAlarm(Alarm):
             'username': "Raid",
             'content': "",
             'icon_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/<pkmn_id>.png",
-            'avatar_url': "https://raw.githubusercontent.com/fosJoddie/PokeAlarm/raids/icons/egg_<raid_level>.png",
+            'avatar_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/egg_<raid_level>.png",
             'title': "Level <raid_level> Raid is available against <pkmn>!",
             'url': "<gmaps>",
             'body': "The raid is available until <24h_time> (<time_left>)."

--- a/PokeAlarm/FacebookPage/FacebookPageAlarm.py
+++ b/PokeAlarm/FacebookPage/FacebookPageAlarm.py
@@ -49,7 +49,7 @@ class FacebookPageAlarm(Alarm):
         },
         'egg': {
             'message': "A level <raid_level> raid is upcoming!",
-            'image': "https://raw.githubusercontent.com/fosJoddie/PokeAlarm/raids/icons/egg_<raid_level>.png",
+            'image': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/egg_<raid_level>.png",
             'link': "<gmaps>",
             'name': 'Egg',
             'description': "The egg will hatch <begin_24h_time> (<begin_time_left>).",

--- a/PokeAlarm/Slack/SlackAlarm.py
+++ b/PokeAlarm/Slack/SlackAlarm.py
@@ -45,7 +45,7 @@ class SlackAlarm(Alarm):
         },
         'egg': {
             'username': "Egg",
-            'icon_url': "https://raw.githubusercontent.com/fosJoddie/PokeAlarm/raids/icons/egg_<raid_level>.png",
+            'icon_url': "https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/egg_<raid_level>.png",
             'title': "A level <raid_level> raid is incoming!",
             'url': "<gmaps>",
             'body': "The egg will hatch <begin_24h_time> (<begin_time_left>)."


### PR DESCRIPTION
## Description
Update the default URIs of raid icons to the master branch

## How Has This Been Tested?
Tested locally 

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
Not applicable 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.