### PR TITLE
Add support for gym DTS into egg and raid alarms

### DIFF
--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -1010,20 +1010,13 @@ class Manager(object):
 
     # Add gym details to an info object
     def add_gym_details(self, info, gym_id):
-        if gym_id in self.__gym_info:
-            gym_info = self.__gym_info[gym_id]
-            info.update({
-                "gym_name": gym_info.get('name', 'unknown'),
-                "gym_description": gym_info.get('description', 'unknown'),
-                "gym_url": gym_info.get('url', 'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons'
-                                               '/gym_0.png')
-            })
-        else:
-            info.update({
-                "gym_name": 'unknown',
-                "gym_description": 'unknown',
-                "gym_url": 'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_0.png'
-            })
+        gym_info = self.__gym_info.get(gym_id,{})
+        info.update({
+            "gym_name": gym_info.get('name', 'unknown'),
+            "gym_description": gym_info.get('description', 'unknown'),
+            "gym_url": gym_info.get('url',
+                                    'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_0.png')
+        })
 
     ####################################################################################################################
 

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -17,7 +17,6 @@ from Filters import Geofence, load_pokemon_section, load_pokestop_section, load_
     load_raid_section
 from Utils import get_cardinal_dir, get_dist_as_str, get_earth_dist, get_path, get_time_as_str, \
     require_and_remove_key, parse_boolean, contains_arg
-
 log = logging.getLogger('Manager')
 
 
@@ -854,8 +853,13 @@ class Manager(object):
 
         time_str = get_time_as_str(egg['raid_end'], self.__timezone)
         start_time_str = get_time_as_str(egg['raid_begin'], self.__timezone)
+        gym_info = self.__gym_info.get(id_, {})
 
         egg.update({
+            "gym_name": gym_info.get('name', 'unknown'),
+            "gym_description": gym_info.get('description', 'unknown'),
+            "gym_url": gym_info.get('url',
+                                    'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_0.png'),
             'time_left': time_str[0],
             '12h_time': time_str[1],
             '24h_time': time_str[2],
@@ -865,8 +869,6 @@ class Manager(object):
             "dist": get_dist_as_str(dist),
             'dir': get_cardinal_dir([lat, lng], self.__latlng)
         })
-
-        self.add_gym_details(egg, id_)
 
         threads = []
         # Spawn notifications in threads so they can work in background
@@ -959,9 +961,14 @@ class Manager(object):
 
         time_str = get_time_as_str(raid['raid_end'], self.__timezone)
         start_time_str = get_time_as_str(raid['raid_begin'], self.__timezone)
+        gym_info = self.__gym_info.get(id_, {})
 
         raid.update({
             'pkmn': name,
+            "gym_name": gym_info.get('name', 'unknown'),
+            "gym_description": gym_info.get('description', 'unknown'),
+            "gym_url": gym_info.get('url',
+                                    'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_0.png'),
             'time_left': time_str[0],
             '12h_time': time_str[1],
             '24h_time': time_str[2],
@@ -973,8 +980,6 @@ class Manager(object):
             'quick_move': self.__move_name.get(quick_id, 'unknown'),
             'charge_move': self.__move_name.get(charge_id, 'unknown')
         })
-
-        self.add_gym_details(raid, id_)
 
         threads = []
         # Spawn notifications in threads so they can work in background
@@ -1007,16 +1012,6 @@ class Manager(object):
             info.update(**self.get_biking_data(lat, lng))
         if self.__api_req['DRIVE_DIST']:
             info.update(**self.get_driving_data(lat, lng))
-
-    # Add gym details to an info object
-    def add_gym_details(self, info, gym_id):
-        gym_info = self.__gym_info.get(gym_id, {})
-        info.update({
-            "gym_name": gym_info.get('name', 'unknown'),
-            "gym_description": gym_info.get('description', 'unknown'),
-            "gym_url": gym_info.get('url',
-                                    'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_0.png')
-        })
 
     ####################################################################################################################
 

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -1010,7 +1010,7 @@ class Manager(object):
 
     # Add gym details to an info object
     def add_gym_details(self, info, gym_id):
-        gym_info = self.__gym_info.get(gym_id,{})
+        gym_info = self.__gym_info.get(gym_id, {})
         info.update({
             "gym_name": gym_info.get('name', 'unknown'),
             "gym_description": gym_info.get('description', 'unknown'),

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -17,11 +17,11 @@ from Filters import Geofence, load_pokemon_section, load_pokestop_section, load_
     load_raid_section
 from Utils import get_cardinal_dir, get_dist_as_str, get_earth_dist, get_path, get_time_as_str, \
     require_and_remove_key, parse_boolean, contains_arg
+
 log = logging.getLogger('Manager')
 
 
 class Manager(object):
-
     def __init__(self, name, google_key, locale, units, timezone, time_limit, max_attempts, location, quiet,
                  filter_file, geofence_file, alarm_file, debug):
         # Set the name of the Manager
@@ -37,7 +37,7 @@ class Manager(object):
 
         # Setup the language-specific stuff
         self.__locale = locale
-        self.__pokemon_name, self.__move_name, self.__team_name, self.__leader = {}, {}, {},  {}
+        self.__pokemon_name, self.__move_name, self.__team_name, self.__leader = {}, {}, {}, {}
         self.update_locales()
 
         self.__units = units  # type of unit used for distances
@@ -317,7 +317,7 @@ class Manager(object):
         for id_ in self.__raid_hist:
             if self.__raid_hist[id_]['raid_end'] < datetime.utcnow():
                 old.append(id_)
-        for id_ in old:     # Remove expired raids
+        for id_ in old:  # Remove expired raids
             del self.__raid_hist[id_]
 
     # Check if a given pokemon is active on a filter
@@ -772,10 +772,12 @@ class Manager(object):
         else:
             log.debug("Gym inside geofences was not checked because no geofences were set.")
 
+        gym_info = self.__gym_info.get(gym_id, {})
+
         gym.update({
-            "name": self.__gym_info[gym_id]['name'],
-            "description": self.__gym_info[gym_id]['description'],
-            "url": self.__gym_info[gym_id]['url'],
+            "name": gym_info.get('name', 'unknown'),
+            "description": gym_info.get('description', 'unknown'),
+            "url": gym_info.get('url', 'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_0.png'),
             "dist": get_dist_as_str(dist),
             'dir': get_cardinal_dir([lat, lng], self.__latlng),
             'new_team': cur_team,
@@ -839,7 +841,7 @@ class Manager(object):
             log.debug("Egg inside geofence was not checked because no geofences were set.")
 
         # check if the level is in the filter range or if we are ignoring eggs
-        passed = self.check_egg_filter(self.__egg_settings,egg)
+        passed = self.check_egg_filter(self.__egg_settings, egg)
 
         if not passed:
             log.debug("Egg {} did not pass filter check".format(id_))
@@ -1011,8 +1013,8 @@ class Manager(object):
         if gym_id in self.__gym_info:
             gym_info = self.__gym_info[gym_id]
             info.update({
-                "gym_name": gym_info.get('name','unknown'),
-                "gym_description": gym_info.get('description','unknown'),
+                "gym_name": gym_info.get('name', 'unknown'),
+                "gym_description": gym_info.get('description', 'unknown'),
                 "gym_url": gym_info.get('url', 'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons'
                                                '/gym_0.png')
             })
@@ -1166,4 +1168,4 @@ class Manager(object):
             log.debug("Stack trace: \n {}".format(traceback.format_exc()))
         return data
 
-    ####################################################################################################################
+        ####################################################################################################################

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -1009,10 +1009,18 @@ class Manager(object):
     # Add gym details to an info object
     def add_gym_details(self, info, gym_id):
         if gym_id in self.__gym_info:
-            info.update( {
-                "gym_name": self.__gym_info[gym_id]['name'],
-                "gym_description": self.__gym_info[gym_id]['description'],
-                "gym_url": self.__gym_info[gym_id]['url']
+            gym_info = self.__gym_info[gym_id]
+            info.update({
+                "gym_name": gym_info.get('name','unknown'),
+                "gym_description": gym_info.get('description','unknown'),
+                "gym_url": gym_info.get('url', 'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons'
+                                               '/gym_0.png')
+            })
+        else:
+            info.update({
+                "gym_name": 'unknown',
+                "gym_description": 'unknown',
+                "gym_url": 'https://raw.githubusercontent.com/kvangent/PokeAlarm/master/icons/gym_0.png'
             })
 
     ####################################################################################################################

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -696,7 +696,6 @@ class Manager(object):
             return
 
         # Extract some basic information
-
         to_team_id = gym['team_id']
         from_team_id = self.__gym_hist.get(gym_id)
 
@@ -1007,7 +1006,8 @@ class Manager(object):
         if self.__api_req['DRIVE_DIST']:
             info.update(**self.get_driving_data(lat, lng))
 
-    def add_gym_details(self, info,gym_id):
+    # Add gym details to an info object
+    def add_gym_details(self, info, gym_id):
         if gym_id in self.__gym_info:
             info.update( {
                 "gym_name": self.__gym_info[gym_id]['name'],

--- a/PokeAlarm/Manager.py
+++ b/PokeAlarm/Manager.py
@@ -679,22 +679,26 @@ class Manager(object):
             thread.join()
 
     def process_gym(self, gym):
+        gym_id = gym['id']
+
+        if self.__gym_settings['enabled'] is True or self.__egg_settings['enabled'] is True \
+                or self.__raid_settings['enabled'] is True:
+            # Update Gym details (if they exist)
+            if gym_id not in self.__gym_info or gym['name'] != 'unknown':
+                self.__gym_info[gym_id] = {
+                    "name": gym['name'],
+                    "description": gym['description'],
+                    "url": gym['url']
+                }
+
         if self.__gym_settings['enabled'] is False:
             log.debug("Gym ignored: notifications are disabled.")
             return
 
         # Extract some basic information
-        gym_id = gym['id']
+
         to_team_id = gym['team_id']
         from_team_id = self.__gym_hist.get(gym_id)
-
-        # Update Gym details (if they exist)
-        if gym_id not in self.__gym_info or gym['name'] != 'unknown':
-            self.__gym_info[gym_id] = {
-                "name": gym['name'],
-                "description": gym['description'],
-                "url": gym['url']
-            }
 
         # Doesn't look like anything to me
         if to_team_id == from_team_id:
@@ -861,6 +865,8 @@ class Manager(object):
             'dir': get_cardinal_dir([lat, lng], self.__latlng)
         })
 
+        self.add_gym_details(egg, id_)
+
         threads = []
         # Spawn notifications in threads so they can work in background
         for alarm in self.__alarms:
@@ -967,6 +973,8 @@ class Manager(object):
             'charge_move': self.__move_name.get(charge_id, 'unknown')
         })
 
+        self.add_gym_details(raid, id_)
+
         threads = []
         # Spawn notifications in threads so they can work in background
         for alarm in self.__alarms:
@@ -998,6 +1006,14 @@ class Manager(object):
             info.update(**self.get_biking_data(lat, lng))
         if self.__api_req['DRIVE_DIST']:
             info.update(**self.get_driving_data(lat, lng))
+
+    def add_gym_details(self, info,gym_id):
+        if gym_id in self.__gym_info:
+            info.update( {
+                "gym_name": self.__gym_info[gym_id]['name'],
+                "gym_description": self.__gym_info[gym_id]['description'],
+                "gym_url": self.__gym_info[gym_id]['url']
+            })
 
     ####################################################################################################################
 


### PR DESCRIPTION
## Description

WIP 
Adds support for gym details in DTS for raid and eggs

* `<gym_name>`
* `<gym_description>`
* `<gym_url>`

Requires RM to scan gym details and send it

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Wiki Update
Will update DTS page with gym info for eggs and raids

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.