### PR TITLE
Add support for RM webhook frames.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,7 @@
 !--- Please post as many details  --
 Operating System  
 Python Version (use `python -V`)  
-PokemonGo-Map startup command `cmd`  
+RocketMap startup command `cmd`  
 PokeAlarm startup command `cmd`
 
 Did the issue persist after restarting the script yesno
@@ -34,7 +34,7 @@ Did the issue persist after restarting the script yesno
 ```
 
 ## Troubleshooting Checklist
-[ ] Most recent version of PokemonGo-Map
+[ ] Most recent version of RocketMap
 [ ] Most recent version of PokeAlarm
 [ ] Checked the Wiki page for service in question
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # It runs with the webhook -wh http://127.0.0.1:4000
 # Usage:
 #   docker build -t pokealarm
-#   docker run -d --net container:PokemonGo-Map --name PokeAlarm -P pokealarm
-# Change "PokemonGo-Map" to the name of your PokemonGo-Map docker
+#   docker run -d --net container:RocketMap --name PokeAlarm -P pokealarm
+# Change "RocketMap" to the name of your RocketMap docker
 # For newer versions of docker maybe you have to change --net to --network
 
 FROM python:2.7-alpine

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -57,7 +57,7 @@ def accept_webhook():
     return "OK"  # request ok
 
 
-# Thread used to distribute the data into various processes (for PokemonGo-Map format)
+# Thread used to distribute the data into various processes (for RocketMap format)
 def manage_webhook_data(queue):
     while True:
         if queue.qsize() > 300:

--- a/start_pokealarm.py
+++ b/start_pokealarm.py
@@ -60,15 +60,22 @@ def accept_webhook():
 # Thread used to distribute the data into various processes (for RocketMap format)
 def manage_webhook_data(queue):
     while True:
-        if queue.qsize() > 300:
+        if queue.qsize() > 200:
             log.warning("Queue length is at {}... this may be causing a delay in notifications.".format(queue.qsize()))
-        data = queue.get(block=True)
-        obj = RocketMap.make_object(data)
-        if obj is not None:
-            for name, mgr in managers.iteritems():
-                mgr.update(obj)
-                log.debug("Distributed to {}.".format(name))
-            log.debug("Finished distributing object with id {}".format(obj['id']))
+
+        # Get next frame.
+        message_frame = queue.get(block=True)
+
+        # Handle each message in the frame.
+        for data in message_frame:
+            obj = RocketMap.make_object(data)
+            if obj is not None:
+                for name, mgr in managers.iteritems():
+                    mgr.update(obj)
+                    log.debug("Distributed to {}.".format(name))
+                log.debug("Finished distributing object with id {}".format(obj['id']))
+
+        # Mark frame as done.
         queue.task_done()
 
 


### PR DESCRIPTION
## Description
* Replaced all instances of "PokemonGo-Map" with "RocketMap".
* Reworked incoming messages to support RM's new webhook frames ([PR 2183](https://github.com/RocketMap/RocketMap/pull/2183)). Will be merged once this PR is merged.
* Reduced the `"Queue length is at {}... this may be causing a delay in notifications"` trigger from 300 to 200 to accommodate the changes in structure.

## How Has This Been Tested?
I didn't, I don't run RocketMap or PokeAlarm instances.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
